### PR TITLE
Activate Travis for omero-marshal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 before_install:
   - wget http://downloads.openmicroscopy.org/ice/experimental/${ICE}.tar.xz
   - tar -xvf ${ICE}.tar.xz
-  - pip install omego pytest
+  - pip install omego pytest flake8
 
 install:
     - omego download --release ${OMERO_VERSION} py
@@ -28,4 +28,5 @@ install:
     - mv OMERO.py* OMERO.py
 
 script:
+    - flake8 .
     - LD_LIBRARY_PATH=./${ICE}/lib PYTHONPATH=./${ICE}/python:./OMERO.py/lib/python:. py.test tests/unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ install:
     - mv OMERO.py* OMERO.py
 
 script:
-    - LD_LIBRARY_PATH=./${ICE}/lib PYTHONPATH=./${ICE}/python:./OMERO.py/lib/python py.test tests/unit
+    - LD_LIBRARY_PATH=./${ICE}/lib PYTHONPATH=./${ICE}/python:./OMERO.py/lib/python:. py.test tests/unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,12 @@ before_install:
   - cd ..
   - tar -xvf "download/${ICE}.tar.xz"
   - ICE_HOME="$(pwd)/${ICE}"
-  - export SLICEPATH="${ICE_HOME}/slice"
-  - export PATH="${ICE_HOME}/bin:$PATH"
-  - export LD_LIBRARY_PATH="${ICE_HOME}/lib:$LD_LIBRARY_PATH"
   - export PYTHONPATH="${ICE_HOME}/python:$PYTHONPATH"
   - pip install omego pytest
 
 
 install:
-    - omego download --release OMERO_VERSION py
+    - omego download --release ${OMERO_VERSION} py
 
 script:
     - PYTHONPATH=$PYTHONPATH:~/OMERO.py/lib/python py.test tests/unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ language: python
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
+addons:
+  apt:
+    packages:
+     - zeroc-ice34
+
 env:
   global:
     - ICE=Ice-3.5.1-b1-ubuntu1204-amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 
 before_install:
   - wget http://downloads.openmicroscopy.org/ice/experimental/${ICE}.tar.xz
-  - tar -xvf download/${ICE}.tar.xz
+  - tar -xvf ${ICE}.tar.xz
   - pip install omego pytest
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ sudo: false
 env:
   global:
     - ICE=Ice-3.5.1-b1-ubuntu1204-amd64
+    - LD_LIBRARY_PATH=$(pwd)/${ICE}/lib
+    - PYTHONPATH=$(pwd)/${ICE}/python:$(pwd)/OMERO.py/lib/python
   matrix:
     - OMERO_VERSION=5.1
     - OMERO_VERSION=5.2
@@ -23,4 +25,4 @@ install:
     - mv OMERO.py* OMERO.py
 
 script:
-    - PYTHONPATH=./${ICE}/python:./OMERO.py/lib/python py.test tests/unit
+    - py.test tests/unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,9 @@ env:
     - OMERO_VERSION=5.2
 
 before_install:
-  - mkdir -p download
-  - cd download
-  - wget "http://downloads.openmicroscopy.org/ice/experimental/${ICE}.tar.xz"
-  - cd ..
-  - tar -xvf "download/${ICE}.tar.xz"
-  - ICE_HOME="$(pwd)/${ICE}"
-  - export PYTHONPATH="${ICE_HOME}/python:$PYTHONPATH"
+  - wget http://downloads.openmicroscopy.org/ice/experimental/${ICE}.tar.xz
+  - tar -xvf download/${ICE}.tar.xz
   - pip install omego pytest
-
 
 install:
     - omego download --release ${OMERO_VERSION} py
@@ -29,4 +23,4 @@ install:
     - mv OMERO.py* OMERO.py
 
 script:
-    - PYTHONPATH=$PYTHONPATH:~/OMERO.py/lib/python py.test tests/unit
+    - PYTHONPATH=./${ICE}/python:./OMERO.py/lib/python py.test tests/unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ sudo: false
 env:
   global:
     - ICE=Ice-3.5.1-b1-ubuntu1204-amd64
-    - LD_LIBRARY_PATH=$(pwd)/${ICE}/lib
-    - PYTHONPATH=$(pwd)/${ICE}/python:$(pwd)/OMERO.py/lib/python
   matrix:
     - OMERO_VERSION=5.1
     - OMERO_VERSION=5.2
@@ -25,4 +23,4 @@ install:
     - mv OMERO.py* OMERO.py
 
 script:
-    - py.test tests/unit
+    - LD_LIBRARY_PATH=./${ICE}/lib PYTHONPATH=./${ICE}/python:./OMERO.py/lib/python py.test tests/unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,19 @@ language: python
 sudo: false
 
 env:
-  - OMERO_VERSION=5.1
-  - OMERO_VERSION=5.2
+  global:
+    - ICE=Ice-3.5.1-b1-ubuntu1204-amd64
+  matrix:
+    - OMERO_VERSION=5.1
+    - OMERO_VERSION=5.2
 
 before_install:
   - mkdir -p download
   - cd download
-  - wget http://downloads.openmicroscopy.org/ice/experimental/Ice-3.5.1-b1-ubuntu1204-amd64.tar.xz
+  - wget "http://downloads.openmicroscopy.org/ice/experimental/${ICE}.tar.xz"
   - cd ..
-  - tar -xvf "download/Ice-3.5.1-b1-ubuntu1204-amd64.tar.xz"
-  - ICE_HOME="$(pwd)/Ice-3.5.1-b1-ubuntu1204-amd64"
+  - tar -xvf "download/${ICE}.tar.xz"
+  - ICE_HOME="$(pwd)/${ICE}"
   - export SLICEPATH="${ICE_HOME}/slice"
   - export PATH="${ICE_HOME}/bin:$PATH"
   - export LD_LIBRARY_PATH="${ICE_HOME}/lib:$LD_LIBRARY_PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,13 @@ env:
     - OMERO_VERSION=5.2
 
 before_install:
-  - wget http://downloads.openmicroscopy.org/ice/experimental/${ICE}.tar.xz
-  - tar -xvf ${ICE}.tar.xz
+  - wget http://downloads.openmicroscopy.org/ice/experimental/${ICE}.tar.xz -O /tmp/${ICE}.tar.xz
+  - tar -xvf /tmp/${ICE}.tar.xz -C /tmp
   - pip install omego pytest flake8
-
-install:
-    - omego download --release ${OMERO_VERSION} py
-    - rm OMERO.py*.zip
-    - mv OMERO.py* OMERO.py
+  - omego download --release ${OMERO_VERSION} py
+  - rm OMERO.py*.zip
+  - mv OMERO.py* /tmp/OMERO.py
 
 script:
     - flake8 .
-    - LD_LIBRARY_PATH=./${ICE}/lib PYTHONPATH=./${ICE}/python:./OMERO.py/lib/python:. py.test tests/unit
+    - LD_LIBRARY_PATH=/tmp/${ICE}/lib PYTHONPATH=./${ICE}/python:/tmp/OMERO.py/lib/python:. py.test tests/unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ before_install:
 
 script:
     - flake8 .
-    - LD_LIBRARY_PATH=/tmp/${ICE}/lib PYTHONPATH=./${ICE}/python:/tmp/OMERO.py/lib/python:. py.test tests/unit
+    - LD_LIBRARY_PATH=/tmp/${ICE}/lib PYTHONPATH=/tmp/${ICE}/python:/tmp/OMERO.py/lib/python:. py.test tests/unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ before_install:
 
 install:
     - omego download --release ${OMERO_VERSION} py
+    - rm OMERO.py*.zip
+    - mv OMERO.py* OMERO.py
 
 script:
     - PYTHONPATH=$PYTHONPATH:~/OMERO.py/lib/python py.test tests/unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: python
+
+# This (sudo: false) is needed to "run on container-based infrastructure" on
+# which cache: is available
+# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
+env:
+  - OMERO_VERSION=5.1
+  - OMERO_VERSION=5.2
+
+before_install:
+  - mkdir -p download
+  - cd download
+  - wget http://downloads.openmicroscopy.org/ice/experimental/Ice-3.5.1-b1-ubuntu1204-amd64.tar.xz
+  - cd ..
+  - tar -xvf "download/Ice-3.5.1-b1-ubuntu1204-amd64.tar.xz"
+  - ICE_HOME="$(pwd)/Ice-3.5.1-b1-ubuntu1204-amd64"
+  - export SLICEPATH="${ICE_HOME}/slice"
+  - export PATH="${ICE_HOME}/bin:$PATH"
+  - export LD_LIBRARY_PATH="${ICE_HOME}/lib:$LD_LIBRARY_PATH"
+  - export PYTHONPATH="${ICE_HOME}/python:$PYTHONPATH"
+  - pip install omego pytest
+
+
+install:
+    - omego download --release OMERO_VERSION py
+
+script:
+    - PYTHONPATH=$PYTHONPATH:~/OMERO.py/lib/python py.test tests/unit

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/openmicroscopy/omero-marshal.png)](http://travis-ci.org/openmicroscopy/omero-marshal)
+
 OMERO Marshal
 =============
 


### PR DESCRIPTION
As discussed with @chris-allan, @jburel and @joshmoore, this PR adds support for Travis in `omero-marshal`. Merging this PR should ensure that for every subsequent change proposed to omero-marshal, the unit tests are automatically run by the Travis build for each of the supported lines of OMERO (currrently 5.1.x and 5.2.x) following the description of https://github.com/openmicroscopy/omero-marshal/pull/2.

The initial Travis build is defined as follows:
- uses a container based Travis
- installs the whitelisted `zeroc-ice34` package for convenience for the Ice dependencies (`libmcpp-dev`)
- downloads the custom OME Ice 3.5 build for Ubuntu 12.04 (also used in https://travis-ci.org/openmicroscopy/openmicroscopy) until the Travis infrastructure is migrating to Ubuntu 14.04
- downloads the release version of OMERO.py  using `omego`
- runs `flake8` on the repository
- runs the `tests/unit` using `py.test`