### PR TITLE
bugfix for non existing (optional) unit type attributes

### DIFF
--- a/omero_marshal/decode/__init__.py
+++ b/omero_marshal/decode/__init__.py
@@ -25,6 +25,8 @@ class Decoder(object):
         self.ctx = ctx
 
     def to_unit(self, v):
+        if v is None:
+            return None
         unit = v['@type'][v['@type'].rfind('#') + 1:]
         unit = getattr(omero.model, unit)
         return unit(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -220,17 +220,19 @@ def roi_with_shapes_and_annotations(roi, ellipse, rectangle):
     return roi
 
 
-def populate_shape(o):
+def populate_shape(o, set_unit_attributes=True):
     o.fillColor = rint(0xffffffff)
     o.fillRule = rstring('solid')
     o.fontFamily = rstring('cursive')
-    o.fontSize = LengthI(12, UnitsLength.POINT)
+    if set_unit_attributes:
+        o.fontSize = LengthI(12, UnitsLength.POINT)
     o.fontStyle = rstring('italic')
     o.locked = rbool(False)
     o.strokeColor = rint(0xffff0000)
     o.strokeDashArray = rstring('inherit')
     o.strokeLineCap = rstring('round')
-    o.strokeWidth = LengthI(4, UnitsLength.PIXEL)
+    if set_unit_attributes:
+        o.strokeWidth = LengthI(4, UnitsLength.PIXEL)
     o.textValue = rstring('the_text')
     o.theC = rint(1)
     o.theT = rint(2)
@@ -323,4 +325,14 @@ def line():
     o.setX2(1)
     o.setY2(2)
     o.id = rlong(6L)
+    return o
+
+
+@pytest.fixture()
+def opt_unit_label():
+    o = LabelI()
+    populate_shape(o, False)
+    o.x = rdouble(1.0)
+    o.y = rdouble(2.0)
+    o.id = rlong(7L)
     return o

--- a/tests/unit/test_shape_decoders.py
+++ b/tests/unit/test_shape_decoders.py
@@ -83,20 +83,27 @@ class TestShapeDecoder(object):
             self.assert_annotations(roi)
         self.assert_details(roi.details)
 
-    def assert_shape(self, shape, has_annotations=False):
+    def assert_shape(self, shape, has_annotations=False, has_unit_information=True):
         assert shape.fillColor.val == 0xffffffff
         assert shape.fillRule.val == 'solid'
         assert shape.strokeColor.val == 0xffff0000
         assert shape.strokeDashArray.val == 'inherit'
-        assert shape.strokeWidth.__class__ is LengthI
-        assert shape.strokeWidth.getUnit() == UnitsLength.PIXEL
-        assert shape.strokeWidth.getValue() == 4
+        if has_unit_information:
+            assert shape.strokeWidth.__class__ is LengthI
+            assert shape.strokeWidth.getUnit() == UnitsLength.PIXEL
+            assert shape.strokeWidth.getValue() == 4
+        else:
+            assert shape.strokeWidth is None
+
         assert shape.strokeLineCap.val == 'round'
         assert shape.textValue.val == 'the_text'
         assert shape.fontFamily.val == 'cursive'
-        assert shape.fontSize.__class__ is LengthI
-        assert shape.fontSize.getUnit() == UnitsLength.POINT
-        assert shape.fontSize.getValue() == 12
+        if has_unit_information:
+            assert shape.fontSize.__class__ is LengthI
+            assert shape.fontSize.getUnit() == UnitsLength.POINT
+            assert shape.fontSize.getValue() == 12
+        else:
+            assert shape.fontSize is None
         assert shape.fontStyle.val == 'italic'
         assert shape.visibility.val is True
         assert shape.locked.val is False
@@ -256,3 +263,17 @@ class TestRoiDecoder(TestShapeDecoder):
         v = encoder.encode(roi_with_shapes_and_annotations)
         v = decoder.decode(v)
         self.assert_roi_with_shapes(v, has_annotations=True)
+
+class TestOptionalUnitInformation(TestShapeDecoder):
+
+    def test_decoder(self, opt_unit_label):
+        encoder = get_encoder(opt_unit_label.__class__)
+        decoder = get_decoder(encoder.TYPE)
+        v = encoder.encode(opt_unit_label)
+        v = decoder.decode(v)
+        self.assert_shape(v, has_unit_information=False)
+        assert v.id.val == 7L
+        assert v.x.__class__ is RDoubleI
+        assert v.x.val == 1.0
+        assert v.y.__class__ is RDoubleI
+        assert v.y.val == 2.0


### PR DESCRIPTION
 that would otherwise raise the following error: 

TypeError: 'NoneType' object has no attribute '__getitem__'