### PR TITLE
Add multi-schema support to omero-marshal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   matrix:
     - OMERO_VERSION=5.1
     - OMERO_VERSION=5.2
+    - OMERO_VERSION=5.3
 
 before_install:
   - wget http://downloads.openmicroscopy.org/ice/experimental/${ICE}.tar.xz -O /tmp/${ICE}.tar.xz

--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -45,11 +45,11 @@ def get_decoder(t):
         return None
 
 
-def get_schema_version(version=omero_version):
+def get_schema_version(version):
     p = re.compile('^(\d+\.\d+\.\d+).*')
     m = p.match(version)
     if m is None:
-        raise Exception("")
+        raise Exception("Invalid OMERO version number")
     v = StrictVersion(m.group(1))
     if (v >= '5.1' and v < '5.3'):
         return '2015-01'
@@ -57,6 +57,8 @@ def get_schema_version(version=omero_version):
         return '2016-06'
     else:
         raise Exception('Unsupported schema version')
+
+SCHEMA_VERSION = get_schema_version(omero_version)
 
 
 class MarshallingCtx(object):

--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -12,10 +12,11 @@
 import importlib
 import pkgutil
 import logging
+import re
 from encode import encoders
 from decode import decoders
+from distutils.version import StrictVersion
 from omero_version import omero_version
-
 
 logger = logging.getLogger('omero-marshal')
 
@@ -44,10 +45,15 @@ def get_decoder(t):
         return None
 
 
-def get_schema_version():
-    if omero_version.startswith('5.1') or omero_version.startswith('5.2'):
+def get_schema_version(version=omero_version):
+    p = re.compile('^(\d+\.\d+\.\d+).*')
+    m = p.match(version)
+    if m is None:
+        raise Exception("")
+    v = StrictVersion(m.group(1))
+    if (v >= '5.1' and v < '5.3'):
         return '2015-01'
-    elif omero_version.startswith('5.3'):
+    elif v >= '5.3':
         return '2016-06'
     else:
         raise Exception('Unsupported schema version')

--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -44,21 +44,32 @@ def get_decoder(t):
         logger.warn('Requested unknown decoder %s' % t, exc_info=True)
         return None
 
+VERSION_REGEXP = re.compile('^(\d+\.\d+\.\d+)')
+
 
 def get_schema_version(version):
-    p = re.compile('^(\d+\.\d+\.\d+).*')
-    m = p.match(version)
+    m = VERSION_REGEXP.search(version)
     if m is None:
-        raise Exception("Invalid OMERO version number")
+        raise Exception("Invalid OMERO version number" + version)
     v = StrictVersion(m.group(1))
-    if (v >= '5.1' and v < '5.3'):
+    if v >= StrictVersion('5.1.0') and v < StrictVersion('5.3.0'):
         return '2015-01'
-    elif v >= '5.3':
+    elif v >= StrictVersion('5.3.0'):
         return '2016-06'
     else:
         raise Exception('Unsupported schema version')
 
 SCHEMA_VERSION = get_schema_version(omero_version)
+BASE_URL = 'http://www.openmicroscopy.org/Schemas'
+if SCHEMA_VERSION == "2015-01":
+    ROI_NS = 'ROI'
+    SA_NS = 'SA'
+else:
+    ROI_NS = 'OME'
+    SA_NS = 'OME'
+OME_SCHEMA_URL = '%s/OME/%s' % (BASE_URL, SCHEMA_VERSION)
+ROI_SCHEMA_URL = '%s/%s/%s' % (BASE_URL, ROI_NS, SCHEMA_VERSION)
+SA_SCHEMA_URL = '%s/%s/%s' % (BASE_URL, SA_NS, SCHEMA_VERSION)
 
 
 class MarshallingCtx(object):

--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -14,6 +14,7 @@ import pkgutil
 import logging
 from encode import encoders
 from decode import decoders
+from omero_version import omero_version
 
 
 logger = logging.getLogger('omero-marshal')
@@ -41,6 +42,15 @@ def get_decoder(t):
     except KeyError:
         logger.warn('Requested unknown decoder %s' % t, exc_info=True)
         return None
+
+
+def get_schema_version():
+    if omero_version.startswith('5.1') or omero_version.startswith('5.2'):
+        return '2015-01'
+    elif omero_version.startswith('5.3'):
+        return '2016-06'
+    else:
+        raise Exception('Unsupported schema version')
 
 
 class MarshallingCtx(object):

--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -50,7 +50,7 @@ VERSION_REGEXP = re.compile('^(\d+\.\d+\.\d+)')
 def get_schema_version(version):
     m = VERSION_REGEXP.search(version)
     if m is None:
-        raise Exception("Invalid OMERO version number" + version)
+        raise Exception("Invalid OMERO version number " + version)
     v = StrictVersion(m.group(1))
     if v >= StrictVersion('5.1.0') and v < StrictVersion('5.3.0'):
         return '2015-01'

--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -50,14 +50,14 @@ VERSION_REGEXP = re.compile('^(\d+\.\d+\.\d+)')
 def get_schema_version(version):
     m = VERSION_REGEXP.search(version)
     if m is None:
-        raise Exception("Invalid OMERO version number " + version)
+        raise Exception("Invalid OMERO version number: " + version)
     v = StrictVersion(m.group(1))
     if v >= StrictVersion('5.1.0') and v < StrictVersion('5.3.0'):
         return '2015-01'
-    elif v >= StrictVersion('5.3.0'):
+    elif v == StrictVersion('5.3.0'):
         return '2016-06'
     else:
-        raise Exception('Unsupported schema version')
+        raise Exception("Unsupported OMERO version: " + version)
 
 SCHEMA_VERSION = get_schema_version(omero_version)
 BASE_URL = 'http://www.openmicroscopy.org/Schemas'

--- a/omero_marshal/decode/decoders/annotation.py
+++ b/omero_marshal/decode/decoders/annotation.py
@@ -9,31 +9,37 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .. import Decoder
 from omero.model import Annotation
 
 
-class AnnotationDecoder(Decoder):
+class Annotation201501Decoder(Decoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01#Annotation'
 
     OMERO_CLASS = Annotation
 
     def decode(self, data):
-        v = super(AnnotationDecoder, self).decode(data)
+        v = super(Annotation201501Decoder, self).decode(data)
         v.description = self.to_rtype(data.get('Description'))
         v.ns = self.to_rtype(data.get('Namespace'))
         return v
 
 
-class AnnotatableDecoder(Decoder):
+class Annotation201606Decoder(Annotation201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Annotation'
+
+
+class Annotatable201501Decoder(Decoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01#AnnotationRef'
 
     OMERO_CLASS = Annotation
 
     def decode(self, data):
-        v = super(AnnotatableDecoder, self).decode(data)
+        v = super(Annotatable201501Decoder, self).decode(data)
         if 'Annotations' in data:
             for annotation in data['Annotations']:
                 annotation_decoder = self.ctx.get_decoder(annotation['@type'])
@@ -43,4 +49,15 @@ class AnnotatableDecoder(Decoder):
         return v
 
 
-decoder = (AnnotationDecoder.TYPE, AnnotationDecoder)
+class Annotatable201606Decoder(Annotatable201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#AnnotationRef'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (Annotation201501Decoder.TYPE, Annotation201501Decoder)
+    AnnotatableDecoder = Annotatable201501Decoder
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (Annotation201606Decoder.TYPE, Annotation201606Decoder)
+    AnnotatableDecoder = Annotatable201606Decoder
+AnnotationDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/boolean_annotation.py
+++ b/omero_marshal/decode/decoders/boolean_annotation.py
@@ -9,19 +9,33 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotationDecoder
 from omero.model import BooleanAnnotationI
 
 
-class BooleanAnnotationDecoder(AnnotationDecoder):
+class BooleanAnnotation201501Decoder(AnnotationDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01#BooleanAnnotation'
 
     OMERO_CLASS = BooleanAnnotationI
 
     def decode(self, data):
-        v = super(BooleanAnnotationDecoder, self).decode(data)
+        v = super(BooleanAnnotation201501Decoder, self).decode(data)
         v.boolValue = self.to_rtype(data.get('Value'))
         return v
 
-decoder = (BooleanAnnotationDecoder.TYPE, BooleanAnnotationDecoder)
+
+class BooleanAnnotation201606Decoder(BooleanAnnotation201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#' \
+        'BooleanAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (BooleanAnnotation201501Decoder.TYPE,
+               BooleanAnnotation201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (BooleanAnnotation201606Decoder.TYPE,
+               BooleanAnnotation201606Decoder)
+BooleanAnnotationDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/comment_annotation.py
+++ b/omero_marshal/decode/decoders/comment_annotation.py
@@ -9,18 +9,32 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .text_annotation import TextAnnotationDecoder
 from omero.model import CommentAnnotationI
 
 
-class CommentAnnotationDecoder(TextAnnotationDecoder):
+class CommentAnnotation201501Decoder(TextAnnotationDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01#CommentAnnotation'
 
     OMERO_CLASS = CommentAnnotationI
 
     def decode(self, data):
-        v = super(CommentAnnotationDecoder, self).decode(data)
+        v = super(CommentAnnotation201501Decoder, self).decode(data)
         return v
 
-decoder = (CommentAnnotationDecoder.TYPE, CommentAnnotationDecoder)
+
+class CommentAnnotation201606Decoder(CommentAnnotation201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#' \
+        'CommentAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (CommentAnnotation201501Decoder.TYPE,
+               CommentAnnotation201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (CommentAnnotation201606Decoder.TYPE,
+               CommentAnnotation201606Decoder)
+CommentAnnotationDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/dataset.py
+++ b/omero_marshal/decode/decoders/dataset.py
@@ -9,20 +9,31 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotatableDecoder
 from omero.model import DatasetI
 
 
-class DatasetDecoder(AnnotatableDecoder):
+class Dataset201501Decoder(AnnotatableDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2015-01#Dataset'
 
     OMERO_CLASS = DatasetI
 
     def decode(self, data):
-        v = super(DatasetDecoder, self).decode(data)
+        v = super(Dataset201501Decoder, self).decode(data)
         v.name = self.to_rtype(data.get('Name'))
         v.description = self.to_rtype(data.get('Description'))
         return v
 
-decoder = (DatasetDecoder.TYPE, DatasetDecoder)
+
+class Dataset201606Decoder(Dataset201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Dataset'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (Dataset201501Decoder.TYPE, Dataset201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (Dataset201606Decoder.TYPE, Dataset201606Decoder)
+DatasetDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/double_annotation.py
+++ b/omero_marshal/decode/decoders/double_annotation.py
@@ -9,19 +9,33 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotationDecoder
 from omero.model import DoubleAnnotationI
 
 
-class DoubleAnnotationDecoder(AnnotationDecoder):
+class DoubleAnnotation201501Decoder(AnnotationDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01#DoubleAnnotation'
 
     OMERO_CLASS = DoubleAnnotationI
 
     def decode(self, data):
-        v = super(DoubleAnnotationDecoder, self).decode(data)
+        v = super(DoubleAnnotation201501Decoder, self).decode(data)
         v.doubleValue = self.to_rtype(data.get('Value'))
         return v
 
-decoder = (DoubleAnnotationDecoder.TYPE, DoubleAnnotationDecoder)
+
+class DoubleAnnotation201606Decoder(DoubleAnnotation201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#' \
+        'DoubleAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (DoubleAnnotation201501Decoder.TYPE,
+               DoubleAnnotation201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (DoubleAnnotation201606Decoder.TYPE,
+               DoubleAnnotation201606Decoder)
+DoubleAnnotationDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/ellipse.py
+++ b/omero_marshal/decode/decoders/ellipse.py
@@ -12,6 +12,7 @@
 from .shape import ShapeDecoder
 from omero.model import EllipseI
 from omero.rtypes import RDoubleI
+from omero_marshal import get_schema_version
 
 
 class EllipseDecoder(ShapeDecoder):
@@ -20,12 +21,30 @@ class EllipseDecoder(ShapeDecoder):
 
     OMERO_CLASS = EllipseI
 
+
+class Ellipse201501Decoder(EllipseDecoder):
+
     def decode(self, data):
-        v = super(EllipseDecoder, self).decode(data)
+        v = super(Ellipse201501Decoder, self).decode(data)
+        v.cx = RDoubleI(data.get('X'))
+        v.cy = RDoubleI(data.get('Y'))
+        v.rx = RDoubleI(data.get('RadiusX'))
+        v.ry = RDoubleI(data.get('RadiusY'))
+        return v
+
+
+class Ellipse201606Decoder(EllipseDecoder):
+
+    def decode(self, data):
+        v = super(Ellipse201606Decoder, self).decode(data)
         v.x = RDoubleI(data.get('X'))
         v.y = RDoubleI(data.get('Y'))
         v.radiusX = RDoubleI(data.get('RadiusX'))
         v.radiusY = RDoubleI(data.get('RadiusY'))
         return v
 
-decoder = (EllipseDecoder.TYPE, EllipseDecoder)
+
+if get_schema_version() == '2015-01':
+    decoder = (Ellipse201501Decoder.TYPE, Ellipse201501Decoder)
+elif get_schema_version() == '2016-06':
+    decoder = (Ellipse201606Decoder.TYPE, Ellipse201606Decoder)

--- a/omero_marshal/decode/decoders/ellipse.py
+++ b/omero_marshal/decode/decoders/ellipse.py
@@ -29,20 +29,16 @@ class Ellipse201501Decoder(ShapeDecoder):
         self.set_radiusY(v, RDoubleI(data.get('RadiusY')))
         return v
 
-    @staticmethod
-    def set_x(obj, value):
+    def set_x(self, obj, value):
         obj.cx = value
 
-    @staticmethod
-    def set_y(obj, value):
+    def set_y(self, obj, value):
         obj.cy = value
 
-    @staticmethod
-    def set_radiusX(obj, value):
+    def set_radiusX(self, obj, value):
         obj.rx = value
 
-    @staticmethod
-    def set_radiusY(obj, value):
+    def set_radiusY(self, obj, value):
         obj.ry = value
 
 
@@ -50,20 +46,16 @@ class Ellipse201606Decoder(Ellipse201501Decoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Ellipse'
 
-    @staticmethod
-    def set_x(obj, value):
+    def set_x(self, obj, value):
         obj.x = value
 
-    @staticmethod
-    def set_y(obj, value):
+    def set_y(self, obj, value):
         obj.y = value
 
-    @staticmethod
-    def set_radiusX(obj, value):
+    def set_radiusX(self, obj, value):
         obj.radiusX = value
 
-    @staticmethod
-    def set_radiusY(obj, value):
+    def set_radiusY(self, obj, value):
         obj.radiusY = value
 
 

--- a/omero_marshal/decode/decoders/ellipse.py
+++ b/omero_marshal/decode/decoders/ellipse.py
@@ -15,36 +15,60 @@ from omero.model import EllipseI
 from omero.rtypes import RDoubleI
 
 
-class EllipseDecoder(ShapeDecoder):
+class Ellipse201501Decoder(ShapeDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Ellipse'
 
     OMERO_CLASS = EllipseI
 
-
-class Ellipse201501Decoder(EllipseDecoder):
-
     def decode(self, data):
         v = super(Ellipse201501Decoder, self).decode(data)
-        v.cx = RDoubleI(data.get('X'))
-        v.cy = RDoubleI(data.get('Y'))
-        v.rx = RDoubleI(data.get('RadiusX'))
-        v.ry = RDoubleI(data.get('RadiusY'))
+        self.set_x(v, RDoubleI(data.get('X')))
+        self.set_y(v, RDoubleI(data.get('Y')))
+        self.set_radiusX(v, RDoubleI(data.get('RadiusX')))
+        self.set_radiusY(v, RDoubleI(data.get('RadiusY')))
         return v
 
+    @staticmethod
+    def set_x(obj, value):
+        obj.cx = value
 
-class Ellipse201606Decoder(EllipseDecoder):
+    @staticmethod
+    def set_y(obj, value):
+        obj.cy = value
 
-    def decode(self, data):
-        v = super(Ellipse201606Decoder, self).decode(data)
-        v.x = RDoubleI(data.get('X'))
-        v.y = RDoubleI(data.get('Y'))
-        v.radiusX = RDoubleI(data.get('RadiusX'))
-        v.radiusY = RDoubleI(data.get('RadiusY'))
-        return v
+    @staticmethod
+    def set_radiusX(obj, value):
+        obj.rx = value
+
+    @staticmethod
+    def set_radiusY(obj, value):
+        obj.ry = value
+
+
+class Ellipse201606Decoder(Ellipse201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Ellipse'
+
+    @staticmethod
+    def set_x(obj, value):
+        obj.x = value
+
+    @staticmethod
+    def set_y(obj, value):
+        obj.y = value
+
+    @staticmethod
+    def set_radiusX(obj, value):
+        obj.radiusX = value
+
+    @staticmethod
+    def set_radiusY(obj, value):
+        obj.radiusY = value
 
 
 if SCHEMA_VERSION == '2015-01':
     decoder = (Ellipse201501Decoder.TYPE, Ellipse201501Decoder)
 elif SCHEMA_VERSION == '2016-06':
     decoder = (Ellipse201606Decoder.TYPE, Ellipse201606Decoder)
+EllipseDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/ellipse.py
+++ b/omero_marshal/decode/decoders/ellipse.py
@@ -12,7 +12,7 @@
 from .shape import ShapeDecoder
 from omero.model import EllipseI
 from omero.rtypes import RDoubleI
-from omero_marshal import get_schema_version
+from omero_marshal import SCHEMA_VERSION
 
 
 class EllipseDecoder(ShapeDecoder):
@@ -44,7 +44,7 @@ class Ellipse201606Decoder(EllipseDecoder):
         return v
 
 
-if get_schema_version() == '2015-01':
+if SCHEMA_VERSION == '2015-01':
     decoder = (Ellipse201501Decoder.TYPE, Ellipse201501Decoder)
-elif get_schema_version() == '2016-06':
+elif SCHEMA_VERSION == '2016-06':
     decoder = (Ellipse201606Decoder.TYPE, Ellipse201606Decoder)

--- a/omero_marshal/decode/decoders/ellipse.py
+++ b/omero_marshal/decode/decoders/ellipse.py
@@ -22,10 +22,10 @@ class EllipseDecoder(ShapeDecoder):
 
     def decode(self, data):
         v = super(EllipseDecoder, self).decode(data)
-        v.cx = RDoubleI(data.get('X'))
-        v.cy = RDoubleI(data.get('Y'))
-        v.rx = RDoubleI(data.get('RadiusX'))
-        v.ry = RDoubleI(data.get('RadiusY'))
+        v.x = RDoubleI(data.get('X'))
+        v.y = RDoubleI(data.get('Y'))
+        v.radiusx = RDoubleI(data.get('RadiusX'))
+        v.radiusy = RDoubleI(data.get('RadiusY'))
         return v
 
 decoder = (EllipseDecoder.TYPE, EllipseDecoder)

--- a/omero_marshal/decode/decoders/ellipse.py
+++ b/omero_marshal/decode/decoders/ellipse.py
@@ -24,8 +24,8 @@ class EllipseDecoder(ShapeDecoder):
         v = super(EllipseDecoder, self).decode(data)
         v.x = RDoubleI(data.get('X'))
         v.y = RDoubleI(data.get('Y'))
-        v.radiusx = RDoubleI(data.get('RadiusX'))
-        v.radiusy = RDoubleI(data.get('RadiusY'))
+        v.radiusX = RDoubleI(data.get('RadiusX'))
+        v.radiusY = RDoubleI(data.get('RadiusY'))
         return v
 
 decoder = (EllipseDecoder.TYPE, EllipseDecoder)

--- a/omero_marshal/decode/decoders/ellipse.py
+++ b/omero_marshal/decode/decoders/ellipse.py
@@ -9,10 +9,10 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .shape import ShapeDecoder
 from omero.model import EllipseI
 from omero.rtypes import RDoubleI
-from omero_marshal import SCHEMA_VERSION
 
 
 class EllipseDecoder(ShapeDecoder):

--- a/omero_marshal/decode/decoders/experimenter.py
+++ b/omero_marshal/decode/decoders/experimenter.py
@@ -9,18 +9,19 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .. import Decoder
 from omero.model import ExperimenterI
 
 
-class ExperimenterDecoder(Decoder):
+class Experimenter201501Decoder(Decoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2015-01#Experimenter'
 
     OMERO_CLASS = ExperimenterI
 
     def decode(self, data):
-        v = super(ExperimenterDecoder, self).decode(data)
+        v = super(Experimenter201501Decoder, self).decode(data)
         v.firstName = self.to_rtype(data.get('FirstName'))
         v.middleName = self.to_rtype(data.get('MiddleName'))
         v.lastName = self.to_rtype(data.get('LastName'))
@@ -29,4 +30,14 @@ class ExperimenterDecoder(Decoder):
         v.omeName = self.to_rtype(data.get('UserName'))
         return v
 
-decoder = (ExperimenterDecoder.TYPE, ExperimenterDecoder)
+
+class Experimenter201606Decoder(Experimenter201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Experimenter'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (Experimenter201501Decoder.TYPE, Experimenter201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (Experimenter201606Decoder.TYPE, Experimenter201606Decoder)
+ExperimenterDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/experimentergroup.py
+++ b/omero_marshal/decode/decoders/experimentergroup.py
@@ -9,11 +9,12 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .. import Decoder
 from omero.model import ExperimenterGroupI
 
 
-class ExperimenterGroupDecoder(Decoder):
+class ExperimenterGroup201501Decoder(Decoder):
 
     TYPE = \
         'http://www.openmicroscopy.org/Schemas/OME/2015-01#ExperimenterGroup'
@@ -21,9 +22,22 @@ class ExperimenterGroupDecoder(Decoder):
     OMERO_CLASS = ExperimenterGroupI
 
     def decode(self, data):
-        v = super(ExperimenterGroupDecoder, self).decode(data)
+        v = super(ExperimenterGroup201501Decoder, self).decode(data)
         v.description = self.to_rtype(data.get('Description'))
         v.name = self.to_rtype(data.get('Name'))
         return v
 
-decoder = (ExperimenterGroupDecoder.TYPE, ExperimenterGroupDecoder)
+
+class ExperimenterGroup201606Decoder(ExperimenterGroup201501Decoder):
+
+    TYPE = \
+        'http://www.openmicroscopy.org/Schemas/OME/2016-06#ExperimenterGroup'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (ExperimenterGroup201501Decoder.TYPE,
+               ExperimenterGroup201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (ExperimenterGroup201606Decoder.TYPE,
+               ExperimenterGroup201606Decoder)
+ExperimenterGroupDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/label.py
+++ b/omero_marshal/decode/decoders/label.py
@@ -9,21 +9,32 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .shape import ShapeDecoder
 from omero.model import LabelI
 from omero.rtypes import RDoubleI
 
 
-class LabelDecoder(ShapeDecoder):
+class Label201501Decoder(ShapeDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Label'
 
     OMERO_CLASS = LabelI
 
     def decode(self, data):
-        v = super(LabelDecoder, self).decode(data)
+        v = super(Label201501Decoder, self).decode(data)
         v.x = RDoubleI(data.get('X'))
         v.y = RDoubleI(data.get('Y'))
         return v
 
-decoder = (LabelDecoder.TYPE, LabelDecoder)
+
+class Label201606Decoder(Label201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Label'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (Label201501Decoder.TYPE, Label201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (Label201606Decoder.TYPE, Label201606Decoder)
+LabelDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/line.py
+++ b/omero_marshal/decode/decoders/line.py
@@ -9,23 +9,34 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .shape import ShapeDecoder
 from omero.model import LineI
 from omero.rtypes import RDoubleI
 
 
-class LineDecoder(ShapeDecoder):
+class Line201501Decoder(ShapeDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Line'
 
     OMERO_CLASS = LineI
 
     def decode(self, data):
-        v = super(LineDecoder, self).decode(data)
+        v = super(Line201501Decoder, self).decode(data)
         v.x1 = RDoubleI(data.get('X1'))
         v.y1 = RDoubleI(data.get('Y1'))
         v.x2 = RDoubleI(data.get('X2'))
         v.y2 = RDoubleI(data.get('Y2'))
         return v
 
-decoder = (LineDecoder.TYPE, LineDecoder)
+
+class Line201606Decoder(Line201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Line'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (Line201501Decoder.TYPE, Line201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (Line201606Decoder.TYPE, Line201606Decoder)
+LineDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/long_annotation.py
+++ b/omero_marshal/decode/decoders/long_annotation.py
@@ -9,19 +9,32 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotationDecoder
 from omero.model import LongAnnotationI
 
 
-class LongAnnotationDecoder(AnnotationDecoder):
+class LongAnnotation201501Decoder(AnnotationDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01#LongAnnotation'
 
     OMERO_CLASS = LongAnnotationI
 
     def decode(self, data):
-        v = super(LongAnnotationDecoder, self).decode(data)
+        v = super(LongAnnotation201501Decoder, self).decode(data)
         v.longValue = self.to_rtype(data.get('Value'))
         return v
 
-decoder = (LongAnnotationDecoder.TYPE, LongAnnotationDecoder)
+
+class LongAnnotation201606Decoder(LongAnnotation201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#LongAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (LongAnnotation201501Decoder.TYPE,
+               LongAnnotation201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (LongAnnotation201606Decoder.TYPE,
+               LongAnnotation201606Decoder)
+LongAnnotationDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/map_annotation.py
+++ b/omero_marshal/decode/decoders/map_annotation.py
@@ -9,18 +9,19 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotationDecoder
 from omero.model import MapAnnotationI, NamedValue
 
 
-class MapAnnotationDecoder(AnnotationDecoder):
+class MapAnnotation201501Decoder(AnnotationDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01#MapAnnotation'
 
     OMERO_CLASS = MapAnnotationI
 
     def decode(self, data):
-        v = super(MapAnnotationDecoder, self).decode(data)
+        v = super(MapAnnotation201501Decoder, self).decode(data)
         map_value = data.get('Value', list())
         map_value = [
             NamedValue(key, value) for key, value in map_value
@@ -28,4 +29,16 @@ class MapAnnotationDecoder(AnnotationDecoder):
         v.setMapValue(map_value)
         return v
 
-decoder = (MapAnnotationDecoder.TYPE, MapAnnotationDecoder)
+
+class MapAnnotation201606Decoder(MapAnnotation201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#MapAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (MapAnnotation201501Decoder.TYPE,
+               MapAnnotation201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (MapAnnotation201606Decoder.TYPE,
+               MapAnnotation201606Decoder)
+MapAnnotationDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/point.py
+++ b/omero_marshal/decode/decoders/point.py
@@ -12,7 +12,7 @@
 from .shape import ShapeDecoder
 from omero.model import PointI
 from omero.rtypes import RDoubleI
-from omero_marshal import get_schema_version
+from omero_marshal import SCHEMA_VERSION
 
 
 class PointDecoder(ShapeDecoder):
@@ -40,7 +40,7 @@ class Point201606Decoder(PointDecoder):
         return v
 
 
-if get_schema_version() == '2015-01':
+if SCHEMA_VERSION == '2015-01':
     decoder = (Point201501Decoder.TYPE, Point201501Decoder)
-elif get_schema_version() == '2016-06':
+elif SCHEMA_VERSION == '2016-06':
     decoder = (Point201606Decoder.TYPE, Point201606Decoder)

--- a/omero_marshal/decode/decoders/point.py
+++ b/omero_marshal/decode/decoders/point.py
@@ -12,6 +12,7 @@
 from .shape import ShapeDecoder
 from omero.model import PointI
 from omero.rtypes import RDoubleI
+from omero_marshal import get_schema_version
 
 
 class PointDecoder(ShapeDecoder):
@@ -20,10 +21,26 @@ class PointDecoder(ShapeDecoder):
 
     OMERO_CLASS = PointI
 
+
+class Point201501Decoder(PointDecoder):
+
+    def decode(self, data):
+        v = super(PointDecoder, self).decode(data)
+        v.cx = RDoubleI(data.get('X'))
+        v.cy = RDoubleI(data.get('Y'))
+        return v
+
+
+class Point201606Decoder(PointDecoder):
+
     def decode(self, data):
         v = super(PointDecoder, self).decode(data)
         v.x = RDoubleI(data.get('X'))
         v.y = RDoubleI(data.get('Y'))
         return v
 
-decoder = (PointDecoder.TYPE, PointDecoder)
+
+if get_schema_version() == '2015-01':
+    decoder = (Point201501Decoder.TYPE, Point201501Decoder)
+elif get_schema_version() == '2016-06':
+    decoder = (Point201606Decoder.TYPE, Point201606Decoder)

--- a/omero_marshal/decode/decoders/point.py
+++ b/omero_marshal/decode/decoders/point.py
@@ -22,8 +22,8 @@ class PointDecoder(ShapeDecoder):
 
     def decode(self, data):
         v = super(PointDecoder, self).decode(data)
-        v.cx = RDoubleI(data.get('X'))
-        v.cy = RDoubleI(data.get('Y'))
+        v.x = RDoubleI(data.get('X'))
+        v.y = RDoubleI(data.get('Y'))
         return v
 
 decoder = (PointDecoder.TYPE, PointDecoder)

--- a/omero_marshal/decode/decoders/point.py
+++ b/omero_marshal/decode/decoders/point.py
@@ -27,12 +27,10 @@ class Point201501Decoder(ShapeDecoder):
         self.set_y(v, RDoubleI(data.get('Y')))
         return v
 
-    @staticmethod
-    def set_x(obj, value):
+    def set_x(self, obj, value):
         obj.cx = value
 
-    @staticmethod
-    def set_y(obj, value):
+    def set_y(self, obj, value):
         obj.cy = value
 
 
@@ -40,12 +38,10 @@ class Point201606Decoder(Point201501Decoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Point'
 
-    @staticmethod
-    def set_x(obj, value):
+    def set_x(self, obj, value):
         obj.x = value
 
-    @staticmethod
-    def set_y(obj, value):
+    def set_y(self, obj, value):
         obj.y = value
 
 

--- a/omero_marshal/decode/decoders/point.py
+++ b/omero_marshal/decode/decoders/point.py
@@ -9,10 +9,10 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .shape import ShapeDecoder
 from omero.model import PointI
 from omero.rtypes import RDoubleI
-from omero_marshal import SCHEMA_VERSION
 
 
 class PointDecoder(ShapeDecoder):

--- a/omero_marshal/decode/decoders/point.py
+++ b/omero_marshal/decode/decoders/point.py
@@ -15,32 +15,42 @@ from omero.model import PointI
 from omero.rtypes import RDoubleI
 
 
-class PointDecoder(ShapeDecoder):
+class Point201501Decoder(ShapeDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Point'
 
     OMERO_CLASS = PointI
 
-
-class Point201501Decoder(PointDecoder):
-
     def decode(self, data):
-        v = super(PointDecoder, self).decode(data)
-        v.cx = RDoubleI(data.get('X'))
-        v.cy = RDoubleI(data.get('Y'))
+        v = super(Point201501Decoder, self).decode(data)
+        self.set_x(v, RDoubleI(data.get('X')))
+        self.set_y(v, RDoubleI(data.get('Y')))
         return v
 
+    @staticmethod
+    def set_x(obj, value):
+        obj.cx = value
 
-class Point201606Decoder(PointDecoder):
+    @staticmethod
+    def set_y(obj, value):
+        obj.cy = value
 
-    def decode(self, data):
-        v = super(PointDecoder, self).decode(data)
-        v.x = RDoubleI(data.get('X'))
-        v.y = RDoubleI(data.get('Y'))
-        return v
+
+class Point201606Decoder(Point201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Point'
+
+    @staticmethod
+    def set_x(obj, value):
+        obj.x = value
+
+    @staticmethod
+    def set_y(obj, value):
+        obj.y = value
 
 
 if SCHEMA_VERSION == '2015-01':
     decoder = (Point201501Decoder.TYPE, Point201501Decoder)
 elif SCHEMA_VERSION == '2016-06':
     decoder = (Point201606Decoder.TYPE, Point201606Decoder)
+PointDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/polygon.py
+++ b/omero_marshal/decode/decoders/polygon.py
@@ -9,19 +9,30 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .shape import ShapeDecoder
 from omero.model import PolygonI
 
 
-class PolygonDecoder(ShapeDecoder):
+class Polygon201501Decoder(ShapeDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Polygon'
 
     OMERO_CLASS = PolygonI
 
     def decode(self, data):
-        v = super(PolygonDecoder, self).decode(data)
+        v = super(Polygon201501Decoder, self).decode(data)
         v.points = self.to_rtype(data.get('Points'))
         return v
 
-decoder = (PolygonDecoder.TYPE, PolygonDecoder)
+
+class Polygon201606Decoder(Polygon201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Polygon'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (Polygon201501Decoder.TYPE, Polygon201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (Polygon201606Decoder.TYPE, Polygon201606Decoder)
+PolygonDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/polyline.py
+++ b/omero_marshal/decode/decoders/polyline.py
@@ -9,19 +9,30 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .shape import ShapeDecoder
 from omero.model import PolylineI
 
 
-class PolylineDecoder(ShapeDecoder):
+class Polyline201501Decoder(ShapeDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Polyline'
 
     OMERO_CLASS = PolylineI
 
     def decode(self, data):
-        v = super(PolylineDecoder, self).decode(data)
+        v = super(Polyline201501Decoder, self).decode(data)
         v.points = self.to_rtype(data.get('Points'))
         return v
 
-decoder = (PolylineDecoder.TYPE, PolylineDecoder)
+
+class Polyline201606Decoder(Polyline201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Polyline'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (Polyline201501Decoder.TYPE, Polyline201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (Polyline201606Decoder.TYPE, Polyline201606Decoder)
+PolylineDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/project.py
+++ b/omero_marshal/decode/decoders/project.py
@@ -9,18 +9,19 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotatableDecoder
 from omero.model import ProjectI
 
 
-class ProjectDecoder(AnnotatableDecoder):
+class Project201501Decoder(AnnotatableDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2015-01#Project'
 
     OMERO_CLASS = ProjectI
 
     def decode(self, data):
-        v = super(ProjectDecoder, self).decode(data)
+        v = super(Project201501Decoder, self).decode(data)
         v.name = self.to_rtype(data.get('Name'))
         v.description = self.to_rtype(data.get('Description'))
         for dataset in data.get('Datasets', list()):
@@ -28,4 +29,14 @@ class ProjectDecoder(AnnotatableDecoder):
             v.linkDataset(dataset_decoder.decode(dataset))
         return v
 
-decoder = (ProjectDecoder.TYPE, ProjectDecoder)
+
+class Project201606Decoder(Project201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Project'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (Project201501Decoder.TYPE, Project201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (Project201606Decoder.TYPE, Project201606Decoder)
+ProjectDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/rectangle.py
+++ b/omero_marshal/decode/decoders/rectangle.py
@@ -9,6 +9,7 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .shape import ShapeDecoder
 from omero.rtypes import RDoubleI
 
@@ -21,18 +22,28 @@ except ImportError:
     from omero.model import RectangleI
 
 
-class RectangleDecoder(ShapeDecoder):
+class Rectangle201501Decoder(ShapeDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Rectangle'
 
     OMERO_CLASS = RectangleI
 
     def decode(self, data):
-        v = super(RectangleDecoder, self).decode(data)
+        v = super(Rectangle201501Decoder, self).decode(data)
         v.x = RDoubleI(data.get('X'))
         v.y = RDoubleI(data.get('Y'))
         v.width = RDoubleI(data.get('Width'))
         v.height = RDoubleI(data.get('Height'))
         return v
 
-decoder = (RectangleDecoder.TYPE, RectangleDecoder)
+
+class Rectangle201606Decoder(Rectangle201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Rectangle'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (Rectangle201501Decoder.TYPE, Rectangle201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (Rectangle201606Decoder.TYPE, Rectangle201606Decoder)
+RectangleDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/roi.py
+++ b/omero_marshal/decode/decoders/roi.py
@@ -9,18 +9,19 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotatableDecoder
 from omero.model import RoiI
 
 
-class RoiDecoder(AnnotatableDecoder):
+class Roi201501Decoder(AnnotatableDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#ROI'
 
     OMERO_CLASS = RoiI
 
     def decode(self, data):
-        v = super(RoiDecoder, self).decode(data)
+        v = super(Roi201501Decoder, self).decode(data)
         v.name = self.to_rtype(data.get('Name'))
         v.description = self.to_rtype(data.get('Description'))
         for shape in data.get('shapes', list()):
@@ -28,4 +29,14 @@ class RoiDecoder(AnnotatableDecoder):
             v.addShape(shape_decoder.decode(shape))
         return v
 
-decoder = (RoiDecoder.TYPE, RoiDecoder)
+
+class Roi201606Decoder(Roi201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (Roi201501Decoder.TYPE, Roi201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (Roi201606Decoder.TYPE, Roi201606Decoder)
+RoiDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/shape.py
+++ b/omero_marshal/decode/decoders/shape.py
@@ -9,9 +9,9 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotatableDecoder
 from omero.model import Shape
-from omero_marshal import SCHEMA_VERSION
 
 
 class ShapeDecoder(AnnotatableDecoder):

--- a/omero_marshal/decode/decoders/shape.py
+++ b/omero_marshal/decode/decoders/shape.py
@@ -11,7 +11,7 @@
 
 from .annotation import AnnotatableDecoder
 from omero.model import Shape
-from omero_marshal import get_schema_version
+from omero_marshal import SCHEMA_VERSION
 
 
 class ShapeDecoder(AnnotatableDecoder):
@@ -35,7 +35,7 @@ class ShapeDecoder(AnnotatableDecoder):
         v.theC = self.to_rtype(data.get('TheC'))
         v.theT = self.to_rtype(data.get('TheT'))
         v.theZ = self.to_rtype(data.get('TheZ'))
-        if get_schema_version() == '2015-01':
+        if SCHEMA_VERSION == '2015-01':
             v.strokeLineCap = self.to_rtype(data.get('LineCap'))
             v.visibility = self.to_rtype(data.get('Visible'))
         return v

--- a/omero_marshal/decode/decoders/shape.py
+++ b/omero_marshal/decode/decoders/shape.py
@@ -14,14 +14,14 @@ from .annotation import AnnotatableDecoder
 from omero.model import Shape
 
 
-class ShapeDecoder(AnnotatableDecoder):
+class Shape201501Decoder(AnnotatableDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Shape'
 
     OMERO_CLASS = Shape
 
     def decode(self, data):
-        v = super(ShapeDecoder, self).decode(data)
+        v = super(Shape201501Decoder, self).decode(data)
         v.fillColor = self.to_rtype(data.get('FillColor'))
         v.fillRule = self.to_rtype(data.get('FillRule'))
         v.fontFamily = self.to_rtype(data.get('FontFamily'))
@@ -35,12 +35,17 @@ class ShapeDecoder(AnnotatableDecoder):
         v.theC = self.to_rtype(data.get('TheC'))
         v.theT = self.to_rtype(data.get('TheT'))
         v.theZ = self.to_rtype(data.get('TheZ'))
-        if SCHEMA_VERSION == '2015-01':
-            v.strokeLineCap = self.to_rtype(data.get('LineCap'))
-            v.visibility = self.to_rtype(data.get('Visible'))
+        self.set_visibility(v, data)
+        self.set_linecap(v, data)
         v.transform = self.to_rtype(
             self.decode_transform(data.get('Transform')))
         return v
+
+    def set_visibility(self, obj, data):
+        obj.visibility = self.to_rtype(data.get('Visible'))
+
+    def set_linecap(self, obj, data):
+        obj.strokeLineCap = self.to_rtype(data.get('LineCap'))
 
     @staticmethod
     def decode_transform(transform):
@@ -56,4 +61,18 @@ class ShapeDecoder(AnnotatableDecoder):
         ]))
 
 
-decoder = (ShapeDecoder.TYPE, ShapeDecoder)
+class Shape201606Decoder(Shape201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Shape'
+
+    def set_visibility(self, obj, data):
+        pass
+
+    def set_linecap(self, obj, value):
+        pass
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (Shape201501Decoder.TYPE, Shape201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (Shape201606Decoder.TYPE, Shape201606Decoder)
+ShapeDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/shape.py
+++ b/omero_marshal/decode/decoders/shape.py
@@ -11,6 +11,7 @@
 
 from .annotation import AnnotatableDecoder
 from omero.model import Shape
+from omero_marshal import get_schema_version
 
 
 class ShapeDecoder(AnnotatableDecoder):
@@ -26,7 +27,6 @@ class ShapeDecoder(AnnotatableDecoder):
         v.fontFamily = self.to_rtype(data.get('FontFamily'))
         v.fontSize = self.to_unit(data.get('FontSize'))
         v.fontStyle = self.to_rtype(data.get('FontStyle'))
-        v.strokeLineCap = self.to_rtype(data.get('LineCap'))
         v.locked = self.to_rtype(data.get('Locked'))
         v.strokeColor = self.to_rtype(data.get('StrokeColor'))
         v.strokeDashArray = self.to_rtype(data.get('StrokeDashArray'))
@@ -35,7 +35,9 @@ class ShapeDecoder(AnnotatableDecoder):
         v.theC = self.to_rtype(data.get('TheC'))
         v.theT = self.to_rtype(data.get('TheT'))
         v.theZ = self.to_rtype(data.get('TheZ'))
-        v.visibility = self.to_rtype(data.get('Visible'))
+        if get_schema_version() == '2015-01':
+            v.strokeLineCap = self.to_rtype(data.get('LineCap'))
+            v.visibility = self.to_rtype(data.get('Visible'))
         return v
 
 decoder = (ShapeDecoder.TYPE, ShapeDecoder)

--- a/omero_marshal/decode/decoders/tag_annotation.py
+++ b/omero_marshal/decode/decoders/tag_annotation.py
@@ -9,18 +9,31 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .text_annotation import TextAnnotationDecoder
 from omero.model import TagAnnotationI
 
 
-class TagAnnotationDecoder(TextAnnotationDecoder):
+class TagAnnotation201501Decoder(TextAnnotationDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01#TagAnnotation'
 
     OMERO_CLASS = TagAnnotationI
 
     def decode(self, data):
-        v = super(TagAnnotationDecoder, self).decode(data)
+        v = super(TagAnnotation201501Decoder, self).decode(data)
         return v
 
-decoder = (TagAnnotationDecoder.TYPE, TagAnnotationDecoder)
+
+class TagAnnotation201606Decoder(TagAnnotation201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#TagAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (TagAnnotation201501Decoder.TYPE,
+               TagAnnotation201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (TagAnnotation201606Decoder.TYPE,
+               TagAnnotation201606Decoder)
+TagAnnotationDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/term_annotation.py
+++ b/omero_marshal/decode/decoders/term_annotation.py
@@ -9,19 +9,32 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotationDecoder
 from omero.model import TermAnnotationI
 
 
-class TermAnnotationDecoder(AnnotationDecoder):
+class TermAnnotation201501Decoder(AnnotationDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01#TermAnnotation'
 
     OMERO_CLASS = TermAnnotationI
 
     def decode(self, data):
-        v = super(TermAnnotationDecoder, self).decode(data)
+        v = super(TermAnnotation201501Decoder, self).decode(data)
         v.termValue = self.to_rtype(data.get('Value'))
         return v
 
-decoder = (TermAnnotationDecoder.TYPE, TermAnnotationDecoder)
+
+class TermAnnotation201606Decoder(TermAnnotation201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#TermAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (TermAnnotation201501Decoder.TYPE,
+               TermAnnotation201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (TermAnnotation201606Decoder.TYPE,
+               TermAnnotation201606Decoder)
+TermAnnotationDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/text_annotation.py
+++ b/omero_marshal/decode/decoders/text_annotation.py
@@ -9,19 +9,32 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotationDecoder
 from omero.model import TextAnnotation
 
 
-class TextAnnotationDecoder(AnnotationDecoder):
+class TextAnnotation201501Decoder(AnnotationDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01#TextAnnotation'
 
     OMERO_CLASS = TextAnnotation
 
     def decode(self, data):
-        v = super(TextAnnotationDecoder, self).decode(data)
+        v = super(TextAnnotation201501Decoder, self).decode(data)
         v.textValue = self.to_rtype(data.get('Value'))
         return v
 
-decoder = (TextAnnotationDecoder.TYPE, TextAnnotationDecoder)
+
+class TextAnnotation201606Decoder(TextAnnotation201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#TextAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (TextAnnotation201501Decoder.TYPE,
+               TextAnnotation201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (TextAnnotation201606Decoder.TYPE,
+               TextAnnotation201606Decoder)
+TextAnnotationDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/timestamp_annotation.py
+++ b/omero_marshal/decode/decoders/timestamp_annotation.py
@@ -9,13 +9,14 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotationDecoder
 from omero.model import TimestampAnnotationI
 
 from omero.rtypes import RTimeI
 
 
-class TimestampAnnotationDecoder(AnnotationDecoder):
+class TimestampAnnotation201501Decoder(AnnotationDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#TimestampAnnotation'
@@ -23,11 +24,24 @@ class TimestampAnnotationDecoder(AnnotationDecoder):
     OMERO_CLASS = TimestampAnnotationI
 
     def decode(self, data):
-        v = super(TimestampAnnotationDecoder, self).decode(data)
+        v = super(TimestampAnnotation201501Decoder, self).decode(data)
         time_value = data.get('Value')
         if time_value is not None:
             time_value = RTimeI(time_value)
         v.timeValue = time_value
         return v
 
-decoder = (TimestampAnnotationDecoder.TYPE, TimestampAnnotationDecoder)
+
+class TimestampAnnotation201606Decoder(TimestampAnnotation201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#' \
+        'TimestampAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (TimestampAnnotation201501Decoder.TYPE,
+               TimestampAnnotation201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (TimestampAnnotation201606Decoder.TYPE,
+               TimestampAnnotation201606Decoder)
+TimestampAnnotationDecoder = decoder[1]

--- a/omero_marshal/decode/decoders/xml_annotation.py
+++ b/omero_marshal/decode/decoders/xml_annotation.py
@@ -9,18 +9,32 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .text_annotation import TextAnnotationDecoder
 from omero.model import XmlAnnotationI
 
 
-class XmlAnnotationDecoder(TextAnnotationDecoder):
+class XmlAnnotation201501Decoder(TextAnnotationDecoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01#XmlAnnotation'
 
     OMERO_CLASS = XmlAnnotationI
 
     def decode(self, data):
-        v = super(XmlAnnotationDecoder, self).decode(data)
+        v = super(XmlAnnotation201501Decoder, self).decode(data)
         return v
 
-decoder = (XmlAnnotationDecoder.TYPE, XmlAnnotationDecoder)
+
+class XmlAnnotation201606Decoder(XmlAnnotation201501Decoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#' \
+        'XmlAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    decoder = (XmlAnnotation201501Decoder.TYPE,
+               XmlAnnotation201501Decoder)
+elif SCHEMA_VERSION == '2016-06':
+    decoder = (XmlAnnotation201606Decoder.TYPE,
+               XmlAnnotation201606Decoder)
+XmlAnnotationDecoder = decoder[1]

--- a/omero_marshal/encode/encoders/annotation.py
+++ b/omero_marshal/encode/encoders/annotation.py
@@ -9,11 +9,12 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .. import Encoder
 from omero.model import Annotation
 
 
-class AnnotationEncoder(Encoder):
+class Annotation201501Encoder(Encoder):
     '''
     Annotation
         BasicAnnotation
@@ -47,18 +48,23 @@ class AnnotationEncoder(Encoder):
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01#Annotation'
 
     def encode(self, obj):
-        v = super(AnnotationEncoder, self).encode(obj)
+        v = super(Annotation201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'Description', obj.description)
         self.set_if_not_none(v, 'Namespace', obj.ns)
         return v
 
 
-class AnnotatableEncoder(Encoder):
+class Annotation201606Encoder(Annotation201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Annotation'
+
+
+class Annotatable201501Encoder(Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01#AnnotationRef'
 
     def encode(self, obj):
-        v = super(AnnotatableEncoder, self).encode(obj)
+        v = super(Annotatable201501Encoder, self).encode(obj)
         if obj.isAnnotationLinksLoaded() and obj.sizeOfAnnotationLinks() > 0:
             annotations = list()
             for annotation_link in obj.copyAnnotationLinks():
@@ -71,4 +77,15 @@ class AnnotatableEncoder(Encoder):
         return v
 
 
-encoder = (Annotation, AnnotationEncoder)
+class Annotatable201606Encoder(Annotatable201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#AnnotationRef'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (Annotation, Annotation201501Encoder)
+    AnnotatableEncoder = Annotatable201501Encoder
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (Annotation, Annotation201606Encoder)
+    AnnotatableEncoder = Annotatable201606Encoder
+AnnotationEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/boolean_annotation.py
+++ b/omero_marshal/encode/encoders/boolean_annotation.py
@@ -9,18 +9,30 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotationEncoder
 from omero.model import BooleanAnnotationI
 
 
-class BooleanAnnotationEncoder(AnnotationEncoder):
+class BooleanAnnotation201501Encoder(AnnotationEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#BooleanAnnotation'
 
     def encode(self, obj):
-        v = super(BooleanAnnotationEncoder, self).encode(obj)
+        v = super(BooleanAnnotation201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'Value', obj.boolValue)
         return v
 
-encoder = (BooleanAnnotationI, BooleanAnnotationEncoder)
+
+class BooleanAnnotation201606Encoder(BooleanAnnotation201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06' \
+        '#BooleanAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (BooleanAnnotationI, BooleanAnnotation201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (BooleanAnnotationI, BooleanAnnotation201606Encoder)
+BooleanAnnotationEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/comment_annotation.py
+++ b/omero_marshal/encode/encoders/comment_annotation.py
@@ -9,17 +9,29 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .text_annotation import TextAnnotationEncoder
 from omero.model import CommentAnnotationI
 
 
-class CommentAnnotationEncoder(TextAnnotationEncoder):
+class CommentAnnotation201501Encoder(TextAnnotationEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#CommentAnnotation'
 
     def encode(self, obj):
-        v = super(CommentAnnotationEncoder, self).encode(obj)
+        v = super(CommentAnnotation201501Encoder, self).encode(obj)
         return v
 
-encoder = (CommentAnnotationI, CommentAnnotationEncoder)
+
+class CommentAnnotation201606Encoder(CommentAnnotation201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06' \
+        '#CommentAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (CommentAnnotationI, CommentAnnotation201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (CommentAnnotationI, CommentAnnotation201606Encoder)
+CommentAnnotationEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/dataset.py
+++ b/omero_marshal/encode/encoders/dataset.py
@@ -9,18 +9,29 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotatableEncoder
 from omero.model import DatasetI
 
 
-class DatasetEncoder(AnnotatableEncoder):
+class Dataset201501Encoder(AnnotatableEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2015-01#Dataset'
 
     def encode(self, obj):
-        v = super(DatasetEncoder, self).encode(obj)
+        v = super(Dataset201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'Name', obj.name)
         self.set_if_not_none(v, 'Description', obj.description)
         return v
 
-encoder = (DatasetI, DatasetEncoder)
+
+class Dataset201606Encoder(Dataset201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Dataset'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (DatasetI, Dataset201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (DatasetI, Dataset201606Encoder)
+DatasetEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/double_annotation.py
+++ b/omero_marshal/encode/encoders/double_annotation.py
@@ -9,18 +9,30 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotationEncoder
 from omero.model import DoubleAnnotationI
 
 
-class DoubleAnnotationEncoder(AnnotationEncoder):
+class DoubleAnnotation201501Encoder(AnnotationEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#DoubleAnnotation'
 
     def encode(self, obj):
-        v = super(DoubleAnnotationEncoder, self).encode(obj)
+        v = super(DoubleAnnotation201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'Value', obj.doubleValue)
         return v
 
-encoder = (DoubleAnnotationI, DoubleAnnotationEncoder)
+
+class DoubleAnnotation201606Encoder(DoubleAnnotation201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06' \
+        '#DoubleAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (DoubleAnnotationI, DoubleAnnotation201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (DoubleAnnotationI, DoubleAnnotation201606Encoder)
+DoubleAnnotationEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/ellipse.py
+++ b/omero_marshal/encode/encoders/ellipse.py
@@ -11,7 +11,7 @@
 
 from .shape import ShapeEncoder
 from omero.model import EllipseI
-from omero_marshal import get_schema_version
+from omero_marshal import SCHEMA_VERSION
 
 
 class EllipseEncoder(ShapeEncoder):
@@ -40,7 +40,7 @@ class Ellipse201501Encoder(EllipseEncoder):
         self.set_if_not_none(v, 'RadiusY', obj.ry)
         return v
 
-if get_schema_version() == '2015-01':
+if SCHEMA_VERSION == '2015-01':
     encoder = (EllipseI, Ellipse201501Encoder)
-elif get_schema_version() == '2016-06':
+elif SCHEMA_VERSION == '2016-06':
     encoder = (EllipseI, Ellipse201606Encoder)

--- a/omero_marshal/encode/encoders/ellipse.py
+++ b/omero_marshal/encode/encoders/ellipse.py
@@ -11,18 +11,36 @@
 
 from .shape import ShapeEncoder
 from omero.model import EllipseI
+from omero_marshal import get_schema_version
 
 
 class EllipseEncoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Ellipse'
 
+
+class Ellipse201606Encoder(EllipseEncoder):
+
     def encode(self, obj):
-        v = super(EllipseEncoder, self).encode(obj)
+        v = super(Ellipse201606Encoder, self).encode(obj)
         self.set_if_not_none(v, 'X', obj.x)
         self.set_if_not_none(v, 'Y', obj.y)
         self.set_if_not_none(v, 'RadiusX', obj.radiusX)
         self.set_if_not_none(v, 'RadiusY', obj.radiusY)
         return v
 
-encoder = (EllipseI, EllipseEncoder)
+
+class Ellipse201501Encoder(EllipseEncoder):
+
+    def encode(self, obj):
+        v = super(Ellipse201501Encoder, self).encode(obj)
+        self.set_if_not_none(v, 'X', obj.cx)
+        self.set_if_not_none(v, 'Y', obj.cy)
+        self.set_if_not_none(v, 'RadiusX', obj.rx)
+        self.set_if_not_none(v, 'RadiusY', obj.ry)
+        return v
+
+if get_schema_version() == '2015-01':
+    encoder = (EllipseI, Ellipse201501Encoder)
+elif get_schema_version() == '2016-06':
+    encoder = (EllipseI, Ellipse201606Encoder)

--- a/omero_marshal/encode/encoders/ellipse.py
+++ b/omero_marshal/encode/encoders/ellipse.py
@@ -26,20 +26,16 @@ class Ellipse201501Encoder(ShapeEncoder):
         self.set_if_not_none(v, 'RadiusY', self.get_radiusY(obj))
         return v
 
-    @staticmethod
-    def get_x(obj):
+    def get_x(self, obj):
         return obj.cx
 
-    @staticmethod
-    def get_y(obj):
+    def get_y(self, obj):
         return obj.cy
 
-    @staticmethod
-    def get_radiusX(obj):
+    def get_radiusX(self, obj):
         return obj.rx
 
-    @staticmethod
-    def get_radiusY(obj):
+    def get_radiusY(self, obj):
         return obj.ry
 
 
@@ -47,20 +43,16 @@ class Ellipse201606Encoder(Ellipse201501Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Ellipse'
 
-    @staticmethod
-    def get_x(obj):
+    def get_x(self, obj):
         return obj.x
 
-    @staticmethod
-    def get_y(obj):
+    def get_y(self, obj):
         return obj.y
 
-    @staticmethod
-    def get_radiusX(obj):
+    def get_radiusX(self, obj):
         return obj.radiusX
 
-    @staticmethod
-    def get_radiusY(obj):
+    def get_radiusY(self, obj):
         return obj.radiusY
 
 

--- a/omero_marshal/encode/encoders/ellipse.py
+++ b/omero_marshal/encode/encoders/ellipse.py
@@ -17,43 +17,29 @@ from omero.model import EllipseI
 class Ellipse201501Encoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Ellipse'
+    X_PROPERTY_NAME = 'cx'
+    Y_PROPERTY_NAME = 'cy'
+    RADIUSX_PROPERTY_NAME = 'rx'
+    RADIUSY_PROPERTY_NAME = 'ry'
 
     def encode(self, obj):
         v = super(Ellipse201501Encoder, self).encode(obj)
-        self.set_if_not_none(v, 'X', self.get_x(obj))
-        self.set_if_not_none(v, 'Y', self.get_y(obj))
-        self.set_if_not_none(v, 'RadiusX', self.get_radiusX(obj))
-        self.set_if_not_none(v, 'RadiusY', self.get_radiusY(obj))
+        self.set_if_not_none(v, 'X', getattr(obj, self.X_PROPERTY_NAME))
+        self.set_if_not_none(v, 'Y', getattr(obj, self.Y_PROPERTY_NAME))
+        self.set_if_not_none(
+            v, 'RadiusX', getattr(obj, self.RADIUSX_PROPERTY_NAME))
+        self.set_if_not_none(
+            v, 'RadiusY', getattr(obj, self.RADIUSY_PROPERTY_NAME))
         return v
-
-    def get_x(self, obj):
-        return obj.cx
-
-    def get_y(self, obj):
-        return obj.cy
-
-    def get_radiusX(self, obj):
-        return obj.rx
-
-    def get_radiusY(self, obj):
-        return obj.ry
 
 
 class Ellipse201606Encoder(Ellipse201501Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Ellipse'
-
-    def get_x(self, obj):
-        return obj.x
-
-    def get_y(self, obj):
-        return obj.y
-
-    def get_radiusX(self, obj):
-        return obj.radiusX
-
-    def get_radiusY(self, obj):
-        return obj.radiusY
+    X_PROPERTY_NAME = 'x'
+    Y_PROPERTY_NAME = 'y'
+    RADIUSX_PROPERTY_NAME = 'radiusX'
+    RADIUSY_PROPERTY_NAME = 'radiusY'
 
 
 if SCHEMA_VERSION == '2015-01':

--- a/omero_marshal/encode/encoders/ellipse.py
+++ b/omero_marshal/encode/encoders/ellipse.py
@@ -19,10 +19,10 @@ class EllipseEncoder(ShapeEncoder):
 
     def encode(self, obj):
         v = super(EllipseEncoder, self).encode(obj)
-        self.set_if_not_none(v, 'X', obj.cx)
+        self.set_if_not_none(v, 'X', obj.x)
         self.set_if_not_none(v, 'Y', obj.cy)
-        self.set_if_not_none(v, 'RadiusX', obj.rx)
-        self.set_if_not_none(v, 'RadiusY', obj.ry)
+        self.set_if_not_none(v, 'RadiusX', obj.radiusx)
+        self.set_if_not_none(v, 'RadiusY', obj.radiusy)
         return v
 
 encoder = (EllipseI, EllipseEncoder)

--- a/omero_marshal/encode/encoders/ellipse.py
+++ b/omero_marshal/encode/encoders/ellipse.py
@@ -9,9 +9,9 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .shape import ShapeEncoder
 from omero.model import EllipseI
-from omero_marshal import SCHEMA_VERSION
 
 
 class EllipseEncoder(ShapeEncoder):

--- a/omero_marshal/encode/encoders/ellipse.py
+++ b/omero_marshal/encode/encoders/ellipse.py
@@ -21,8 +21,8 @@ class EllipseEncoder(ShapeEncoder):
         v = super(EllipseEncoder, self).encode(obj)
         self.set_if_not_none(v, 'X', obj.x)
         self.set_if_not_none(v, 'Y', obj.cy)
-        self.set_if_not_none(v, 'RadiusX', obj.radiusx)
-        self.set_if_not_none(v, 'RadiusY', obj.radiusy)
+        self.set_if_not_none(v, 'RadiusX', obj.radiusX)
+        self.set_if_not_none(v, 'RadiusY', obj.radiusY)
         return v
 
 encoder = (EllipseI, EllipseEncoder)

--- a/omero_marshal/encode/encoders/ellipse.py
+++ b/omero_marshal/encode/encoders/ellipse.py
@@ -14,33 +14,58 @@ from .shape import ShapeEncoder
 from omero.model import EllipseI
 
 
-class EllipseEncoder(ShapeEncoder):
+class Ellipse201501Encoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Ellipse'
 
-
-class Ellipse201606Encoder(EllipseEncoder):
-
-    def encode(self, obj):
-        v = super(Ellipse201606Encoder, self).encode(obj)
-        self.set_if_not_none(v, 'X', obj.x)
-        self.set_if_not_none(v, 'Y', obj.y)
-        self.set_if_not_none(v, 'RadiusX', obj.radiusX)
-        self.set_if_not_none(v, 'RadiusY', obj.radiusY)
-        return v
-
-
-class Ellipse201501Encoder(EllipseEncoder):
-
     def encode(self, obj):
         v = super(Ellipse201501Encoder, self).encode(obj)
-        self.set_if_not_none(v, 'X', obj.cx)
-        self.set_if_not_none(v, 'Y', obj.cy)
-        self.set_if_not_none(v, 'RadiusX', obj.rx)
-        self.set_if_not_none(v, 'RadiusY', obj.ry)
+        self.set_if_not_none(v, 'X', self.get_x(obj))
+        self.set_if_not_none(v, 'Y', self.get_y(obj))
+        self.set_if_not_none(v, 'RadiusX', self.get_radiusX(obj))
+        self.set_if_not_none(v, 'RadiusY', self.get_radiusY(obj))
         return v
+
+    @staticmethod
+    def get_x(obj):
+        return obj.cx
+
+    @staticmethod
+    def get_y(obj):
+        return obj.cy
+
+    @staticmethod
+    def get_radiusX(obj):
+        return obj.rx
+
+    @staticmethod
+    def get_radiusY(obj):
+        return obj.ry
+
+
+class Ellipse201606Encoder(Ellipse201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Ellipse'
+
+    @staticmethod
+    def get_x(obj):
+        return obj.x
+
+    @staticmethod
+    def get_y(obj):
+        return obj.y
+
+    @staticmethod
+    def get_radiusX(obj):
+        return obj.radiusX
+
+    @staticmethod
+    def get_radiusY(obj):
+        return obj.radiusY
+
 
 if SCHEMA_VERSION == '2015-01':
     encoder = (EllipseI, Ellipse201501Encoder)
 elif SCHEMA_VERSION == '2016-06':
     encoder = (EllipseI, Ellipse201606Encoder)
+EllipseEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/ellipse.py
+++ b/omero_marshal/encode/encoders/ellipse.py
@@ -20,7 +20,7 @@ class EllipseEncoder(ShapeEncoder):
     def encode(self, obj):
         v = super(EllipseEncoder, self).encode(obj)
         self.set_if_not_none(v, 'X', obj.x)
-        self.set_if_not_none(v, 'Y', obj.cy)
+        self.set_if_not_none(v, 'Y', obj.y)
         self.set_if_not_none(v, 'RadiusX', obj.radiusX)
         self.set_if_not_none(v, 'RadiusY', obj.radiusY)
         return v

--- a/omero_marshal/encode/encoders/experimenter.py
+++ b/omero_marshal/encode/encoders/experimenter.py
@@ -9,16 +9,17 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .. import Encoder
 from omero.model import ExperimenterI
 
 
-class ExperimenterEncoder(Encoder):
+class Experimenter201501Encoder(Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2015-01#Experimenter'
 
     def encode(self, obj):
-        v = super(ExperimenterEncoder, self).encode(obj)
+        v = super(Experimenter201501Encoder, self).encode(obj)
         if not obj.isLoaded():
             return v
         self.set_if_not_none(v, 'FirstName', obj.firstName)
@@ -29,4 +30,14 @@ class ExperimenterEncoder(Encoder):
         self.set_if_not_none(v, 'UserName', obj.omeName)
         return v
 
-encoder = (ExperimenterI, ExperimenterEncoder)
+
+class Experimenter201606Encoder(Experimenter201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Experimenter'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (ExperimenterI, Experimenter201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (ExperimenterI, Experimenter201606Encoder)
+ExperimenterEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/experimentergroup.py
+++ b/omero_marshal/encode/encoders/experimentergroup.py
@@ -9,21 +9,33 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .. import Encoder
 from omero.model import ExperimenterGroupI
 
 
-class ExperimenterGroupEncoder(Encoder):
+class ExperimenterGroup201501Encoder(Encoder):
 
     TYPE = \
         'http://www.openmicroscopy.org/Schemas/OME/2015-01#ExperimenterGroup'
 
     def encode(self, obj):
-        v = super(ExperimenterGroupEncoder, self).encode(obj)
+        v = super(ExperimenterGroup201501Encoder, self).encode(obj)
         if not obj.isLoaded():
             return v
         self.set_if_not_none(v, 'Description', obj.description)
         self.set_if_not_none(v, 'Name', obj.name)
         return v
 
-encoder = (ExperimenterGroupI, ExperimenterGroupEncoder)
+
+class ExperimenterGroup201606Encoder(ExperimenterGroup201501Encoder):
+
+    TYPE = \
+        'http://www.openmicroscopy.org/Schemas/OME/2016-06#ExperimenterGroup'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (ExperimenterGroupI, ExperimenterGroup201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (ExperimenterGroupI, ExperimenterGroup201606Encoder)
+ExperimenterGroupEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/label.py
+++ b/omero_marshal/encode/encoders/label.py
@@ -9,19 +9,29 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .shape import ShapeEncoder
 from omero.model import LabelI
 
 
-class LabelEncoder(ShapeEncoder):
+class Label201501Encoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Label'
 
     def encode(self, obj):
-        v = super(LabelEncoder, self).encode(obj)
+        v = super(Label201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'X', obj.x)
         self.set_if_not_none(v, 'Y', obj.y)
         return v
 
 
-encoder = (LabelI, LabelEncoder)
+class Label201606Encoder(Label201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Label'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (LabelI, Label201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (LabelI, Label201606Encoder)
+LabelEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/line.py
+++ b/omero_marshal/encode/encoders/line.py
@@ -9,20 +9,31 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .shape import ShapeEncoder
 from omero.model import LineI
 
 
-class LineEncoder(ShapeEncoder):
+class Line201501Encoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Line'
 
     def encode(self, obj):
-        v = super(LineEncoder, self).encode(obj)
+        v = super(Line201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'X1', obj.x1)
         self.set_if_not_none(v, 'Y1', obj.y1)
         self.set_if_not_none(v, 'X2', obj.x2)
         self.set_if_not_none(v, 'Y2', obj.y2)
         return v
 
-encoder = (LineI, LineEncoder)
+
+class Line201606Encoder(Line201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Line'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (LineI, Line201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (LineI, Line201606Encoder)
+LineEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/long_annotation.py
+++ b/omero_marshal/encode/encoders/long_annotation.py
@@ -9,18 +9,30 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotationEncoder
 from omero.model import LongAnnotationI
 
 
-class LongAnnotationEncoder(AnnotationEncoder):
+class LongAnnotation201501Encoder(AnnotationEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#LongAnnotation'
 
     def encode(self, obj):
-        v = super(LongAnnotationEncoder, self).encode(obj)
+        v = super(LongAnnotation201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'Value', obj.longValue)
         return v
 
-encoder = (LongAnnotationI, LongAnnotationEncoder)
+
+class LongAnnotation201606Encoder(LongAnnotation201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06' \
+        '#LongAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (LongAnnotationI, LongAnnotation201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (LongAnnotationI, LongAnnotation201606Encoder)
+LongAnnotationEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/map_annotation.py
+++ b/omero_marshal/encode/encoders/map_annotation.py
@@ -9,17 +9,18 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotationEncoder
 from omero.model import MapAnnotationI
 
 
-class MapAnnotationEncoder(AnnotationEncoder):
+class MapAnnotation201501Encoder(AnnotationEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#MapAnnotation'
 
     def encode(self, obj):
-        v = super(MapAnnotationEncoder, self).encode(obj)
+        v = super(MapAnnotation201501Encoder, self).encode(obj)
         if obj.mapValue is None:
             return None
         self.set_if_not_none(
@@ -29,4 +30,15 @@ class MapAnnotationEncoder(AnnotationEncoder):
         )
         return v
 
-encoder = (MapAnnotationI, MapAnnotationEncoder)
+
+class MapAnnotation201606Encoder(MapAnnotation201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06' \
+        '#MapAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (MapAnnotationI, MapAnnotation201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (MapAnnotationI, MapAnnotation201606Encoder)
+MapAnnotationEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/point.py
+++ b/omero_marshal/encode/encoders/point.py
@@ -19,8 +19,8 @@ class PointEncoder(ShapeEncoder):
 
     def encode(self, obj):
         v = super(PointEncoder, self).encode(obj)
-        self.set_if_not_none(v, 'X', obj.cx)
-        self.set_if_not_none(v, 'Y', obj.cy)
+        self.set_if_not_none(v, 'X', obj.x)
+        self.set_if_not_none(v, 'Y', obj.y)
         return v
 
 encoder = (PointI, PointEncoder)

--- a/omero_marshal/encode/encoders/point.py
+++ b/omero_marshal/encode/encoders/point.py
@@ -11,7 +11,7 @@
 
 from .shape import ShapeEncoder
 from omero.model import PointI
-from omero_marshal import get_schema_version
+from omero_marshal import SCHEMA_VERSION
 
 
 class PointEncoder(ShapeEncoder):
@@ -36,7 +36,7 @@ class Point201501Encoder(PointEncoder):
         self.set_if_not_none(v, 'Y', obj.cy)
         return v
 
-if get_schema_version() == '2015-01':
+if SCHEMA_VERSION == '2015-01':
     encoder = (PointI, Point201501Encoder)
-elif get_schema_version() == '2016-06':
+elif SCHEMA_VERSION == '2016-06':
     encoder = (PointI, Point201606Encoder)

--- a/omero_marshal/encode/encoders/point.py
+++ b/omero_marshal/encode/encoders/point.py
@@ -17,29 +17,21 @@ from omero.model import PointI
 class Point201501Encoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Point'
+    X_PROPERTY_NAME = 'cx'
+    Y_PROPERTY_NAME = 'cy'
 
     def encode(self, obj):
         v = super(Point201501Encoder, self).encode(obj)
-        self.set_if_not_none(v, 'X', self.get_x(obj))
-        self.set_if_not_none(v, 'Y', self.get_y(obj))
+        self.set_if_not_none(v, 'X', getattr(obj, self.X_PROPERTY_NAME))
+        self.set_if_not_none(v, 'Y', getattr(obj, self.Y_PROPERTY_NAME))
         return v
-
-    def get_x(self, obj):
-        return obj.cx
-
-    def get_y(self, obj):
-        return obj.cy
 
 
 class Point201606Encoder(Point201501Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Point'
-
-    def get_x(self, obj):
-        return obj.x
-
-    def get_y(self, obj):
-        return obj.y
+    X_PROPERTY_NAME = 'x'
+    Y_PROPERTY_NAME = 'y'
 
 
 if SCHEMA_VERSION == '2015-01':

--- a/omero_marshal/encode/encoders/point.py
+++ b/omero_marshal/encode/encoders/point.py
@@ -11,16 +11,32 @@
 
 from .shape import ShapeEncoder
 from omero.model import PointI
+from omero_marshal import get_schema_version
 
 
 class PointEncoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Point'
 
+
+class Point201606Encoder(PointEncoder):
+
     def encode(self, obj):
-        v = super(PointEncoder, self).encode(obj)
+        v = super(Point201606Encoder, self).encode(obj)
         self.set_if_not_none(v, 'X', obj.x)
         self.set_if_not_none(v, 'Y', obj.y)
         return v
 
-encoder = (PointI, PointEncoder)
+
+class Point201501Encoder(PointEncoder):
+
+    def encode(self, obj):
+        v = super(Point201501Encoder, self).encode(obj)
+        self.set_if_not_none(v, 'X', obj.cx)
+        self.set_if_not_none(v, 'Y', obj.cy)
+        return v
+
+if get_schema_version() == '2015-01':
+    encoder = (PointI, Point201501Encoder)
+elif get_schema_version() == '2016-06':
+    encoder = (PointI, Point201606Encoder)

--- a/omero_marshal/encode/encoders/point.py
+++ b/omero_marshal/encode/encoders/point.py
@@ -24,12 +24,10 @@ class Point201501Encoder(ShapeEncoder):
         self.set_if_not_none(v, 'Y', self.get_y(obj))
         return v
 
-    @staticmethod
-    def get_x(obj):
+    def get_x(self, obj):
         return obj.cx
 
-    @staticmethod
-    def get_y(obj):
+    def get_y(self, obj):
         return obj.cy
 
 
@@ -37,12 +35,10 @@ class Point201606Encoder(Point201501Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Point'
 
-    @staticmethod
-    def get_x(obj):
+    def get_x(self, obj):
         return obj.x
 
-    @staticmethod
-    def get_y(obj):
+    def get_y(self, obj):
         return obj.y
 
 

--- a/omero_marshal/encode/encoders/point.py
+++ b/omero_marshal/encode/encoders/point.py
@@ -14,29 +14,40 @@ from .shape import ShapeEncoder
 from omero.model import PointI
 
 
-class PointEncoder(ShapeEncoder):
+class Point201501Encoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Point'
 
-
-class Point201606Encoder(PointEncoder):
-
-    def encode(self, obj):
-        v = super(Point201606Encoder, self).encode(obj)
-        self.set_if_not_none(v, 'X', obj.x)
-        self.set_if_not_none(v, 'Y', obj.y)
-        return v
-
-
-class Point201501Encoder(PointEncoder):
-
     def encode(self, obj):
         v = super(Point201501Encoder, self).encode(obj)
-        self.set_if_not_none(v, 'X', obj.cx)
-        self.set_if_not_none(v, 'Y', obj.cy)
+        self.set_if_not_none(v, 'X', self.get_x(obj))
+        self.set_if_not_none(v, 'Y', self.get_y(obj))
         return v
+
+    @staticmethod
+    def get_x(obj):
+        return obj.cx
+
+    @staticmethod
+    def get_y(obj):
+        return obj.cy
+
+
+class Point201606Encoder(Point201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Point'
+
+    @staticmethod
+    def get_x(obj):
+        return obj.x
+
+    @staticmethod
+    def get_y(obj):
+        return obj.y
+
 
 if SCHEMA_VERSION == '2015-01':
     encoder = (PointI, Point201501Encoder)
 elif SCHEMA_VERSION == '2016-06':
     encoder = (PointI, Point201606Encoder)
+PointEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/point.py
+++ b/omero_marshal/encode/encoders/point.py
@@ -9,9 +9,9 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .shape import ShapeEncoder
 from omero.model import PointI
-from omero_marshal import SCHEMA_VERSION
 
 
 class PointEncoder(ShapeEncoder):

--- a/omero_marshal/encode/encoders/polygon.py
+++ b/omero_marshal/encode/encoders/polygon.py
@@ -9,17 +9,28 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .shape import ShapeEncoder
 from omero.model import PolygonI
 
 
-class PolygonEncoder(ShapeEncoder):
+class Polygon201501Encoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Polygon'
 
     def encode(self, obj):
-        v = super(PolygonEncoder, self).encode(obj)
+        v = super(Polygon201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'Points', obj.points)
         return v
 
-encoder = (PolygonI, PolygonEncoder)
+
+class Polygon201606Encoder(Polygon201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Polygon'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (PolygonI, Polygon201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (PolygonI, Polygon201606Encoder)
+PolygonEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/polyline.py
+++ b/omero_marshal/encode/encoders/polyline.py
@@ -9,17 +9,28 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .shape import ShapeEncoder
 from omero.model import PolylineI
 
 
-class PolylineEncoder(ShapeEncoder):
+class Polyline201501Encoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Polyline'
 
     def encode(self, obj):
-        v = super(PolylineEncoder, self).encode(obj)
+        v = super(Polyline201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'Points', obj.points)
         return v
 
-encoder = (PolylineI, PolylineEncoder)
+
+class Polyline201606Encoder(Polyline201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Polyline'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (PolylineI, Polyline201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (PolylineI, Polyline201606Encoder)
+PolylineEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/project.py
+++ b/omero_marshal/encode/encoders/project.py
@@ -9,16 +9,17 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotatableEncoder
 from omero.model import ProjectI
 
 
-class ProjectEncoder(AnnotatableEncoder):
+class Project201501Encoder(AnnotatableEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2015-01#Project'
 
     def encode(self, obj):
-        v = super(ProjectEncoder, self).encode(obj)
+        v = super(Project201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'Name', obj.name)
         self.set_if_not_none(v, 'Description', obj.description)
         if obj.isDatasetLinksLoaded() and obj.sizeOfDatasetLinks() > 0:
@@ -32,4 +33,14 @@ class ProjectEncoder(AnnotatableEncoder):
             v['Datasets'] = datasets
         return v
 
-encoder = (ProjectI, ProjectEncoder)
+
+class Project201606Encoder(Project201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Project'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (ProjectI, Project201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (ProjectI, Project201606Encoder)
+ProjectEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/rectangle.py
+++ b/omero_marshal/encode/encoders/rectangle.py
@@ -9,6 +9,7 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .shape import ShapeEncoder
 
 # Handle differences in class naming between OMERO 5.1.x and 5.2.x
@@ -20,16 +21,26 @@ except ImportError:
     from omero.model import RectangleI
 
 
-class RectangleEncoder(ShapeEncoder):
+class Rectangle201501Encoder(ShapeEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Rectangle'
 
     def encode(self, obj):
-        v = super(RectangleEncoder, self).encode(obj)
+        v = super(Rectangle201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'X', obj.x)
         self.set_if_not_none(v, 'Y', obj.y)
         self.set_if_not_none(v, 'Width', obj.width)
         self.set_if_not_none(v, 'Height', obj.height)
         return v
 
-encoder = (RectangleI, RectangleEncoder)
+
+class Rectangle201606Encoder(Rectangle201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Rectangle'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (RectangleI, Rectangle201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (RectangleI, Rectangle201606Encoder)
+RectangleEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/roi.py
+++ b/omero_marshal/encode/encoders/roi.py
@@ -9,16 +9,17 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotatableEncoder
 from omero.model import RoiI
 
 
-class RoiEncoder(AnnotatableEncoder):
+class Roi201501Encoder(AnnotatableEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#ROI'
 
     def encode(self, obj):
-        v = super(RoiEncoder, self).encode(obj)
+        v = super(Roi201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'Name', obj.name)
         self.set_if_not_none(v, 'Description', obj.description)
         if obj.isShapesLoaded() and obj.sizeOfShapes() > 0:
@@ -29,4 +30,14 @@ class RoiEncoder(AnnotatableEncoder):
             v['shapes'] = shapes
         return v
 
-encoder = (RoiI, RoiEncoder)
+
+class Roi201606Encoder(Roi201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#ROI'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (RoiI, Roi201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (RoiI, Roi201606Encoder)
+RoiEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/shape.py
+++ b/omero_marshal/encode/encoders/shape.py
@@ -16,12 +16,12 @@ from omero.rtypes import unwrap
 from math import sin, cos, radians
 
 
-class ShapeEncoder(AnnotatableEncoder):
+class Shape201501Encoder(AnnotatableEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Shape'
 
     def encode(self, obj):
-        v = super(ShapeEncoder, self).encode(obj)
+        v = super(Shape201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'FillColor', obj.fillColor)
         self.set_if_not_none(v, 'FillRule', obj.fillRule)
         self.set_if_not_none(v, 'FontFamily', obj.fontFamily)
@@ -37,10 +37,15 @@ class ShapeEncoder(AnnotatableEncoder):
         self.set_if_not_none(v, 'TheZ', obj.theZ)
         self.set_if_not_none(
             v, 'Transform', self.encode_transform(obj.transform))
-        if SCHEMA_VERSION == '2015-01':
-            self.set_if_not_none(v, 'LineCap', obj.strokeLineCap)
-            self.set_if_not_none(v, 'Visible', obj.visibility)
+        self.set_linecap(v, obj)
+        self.set_visible(v, obj)
         return v
+
+    def set_linecap(self, v, obj):
+        self.set_if_not_none(v, 'LineCap', obj.strokeLineCap)
+
+    def set_visible(self, v, obj):
+        self.set_if_not_none(v, 'Visible', obj.visibility)
 
     @staticmethod
     def encode_transform(transform):
@@ -86,4 +91,19 @@ class ShapeEncoder(AnnotatableEncoder):
         }
 
 
-encoder = (Shape, ShapeEncoder)
+class Shape201606Encoder(Shape201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Shape'
+
+    def set_linecap(self, v, obj):
+        pass
+
+    def set_visible(self, v, obj):
+        pass
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (Shape, Shape201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (Shape, Shape201606Encoder)
+ShapeEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/shape.py
+++ b/omero_marshal/encode/encoders/shape.py
@@ -107,6 +107,22 @@ class Shape201606Encoder(Shape201501Encoder):
         return 'http://www.openmicroscopy.org/Schemas/OME/2016-06' \
             '#AffineTransform'
 
+    def encode_transform(self, transform):
+        if (transform.getA00() is None and transform.getA10() is None and
+                transform.getA01() is None and transform.getA11() is None and
+                transform.getA02() is None and transform.getA12() is None):
+            return None
+        print transform
+
+        return {
+            '@type': self.get_transform_type(),
+            'A00': transform.getA00().val,
+            'A10': transform.getA10().val,
+            'A01': transform.getA01().val,
+            'A11': transform.getA11().val,
+            'A02': transform.getA02().val,
+            'A12': transform.getA12().val,
+        }
 
 if SCHEMA_VERSION == '2015-01':
     encoder = (Shape, Shape201501Encoder)

--- a/omero_marshal/encode/encoders/shape.py
+++ b/omero_marshal/encode/encoders/shape.py
@@ -108,11 +108,12 @@ class Shape201606Encoder(Shape201501Encoder):
             '#AffineTransform'
 
     def encode_transform(self, transform):
+        if not transform:
+            return None
         if (transform.getA00() is None and transform.getA10() is None and
                 transform.getA01() is None and transform.getA11() is None and
                 transform.getA02() is None and transform.getA12() is None):
             return None
-        print transform
 
         return {
             '@type': self.get_transform_type(),

--- a/omero_marshal/encode/encoders/shape.py
+++ b/omero_marshal/encode/encoders/shape.py
@@ -11,6 +11,7 @@
 
 from .annotation import AnnotatableEncoder
 from omero.model import Shape
+from omero_marshal import get_schema_version
 
 
 class ShapeEncoder(AnnotatableEncoder):
@@ -24,7 +25,6 @@ class ShapeEncoder(AnnotatableEncoder):
         self.set_if_not_none(v, 'FontFamily', obj.fontFamily)
         self.set_if_not_none(v, 'FontSize', obj.fontSize)
         self.set_if_not_none(v, 'FontStyle', obj.fontStyle)
-        self.set_if_not_none(v, 'LineCap', obj.strokeLineCap)
         self.set_if_not_none(v, 'Locked', obj.locked)
         self.set_if_not_none(v, 'StrokeColor', obj.strokeColor)
         self.set_if_not_none(v, 'StrokeDashArray', obj.strokeDashArray)
@@ -33,7 +33,9 @@ class ShapeEncoder(AnnotatableEncoder):
         self.set_if_not_none(v, 'TheC', obj.theC)
         self.set_if_not_none(v, 'TheT', obj.theT)
         self.set_if_not_none(v, 'TheZ', obj.theZ)
-        self.set_if_not_none(v, 'Visible', obj.visibility)
+        if get_schema_version() == '2015-01':
+            self.set_if_not_none(v, 'LineCap', obj.strokeLineCap)
+            self.set_if_not_none(v, 'Visible', obj.visibility)
         return v
 
 encoder = (Shape, ShapeEncoder)

--- a/omero_marshal/encode/encoders/shape.py
+++ b/omero_marshal/encode/encoders/shape.py
@@ -9,9 +9,9 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotatableEncoder
 from omero.model import Shape
-from omero_marshal import SCHEMA_VERSION
 from omero.rtypes import unwrap
 from math import sin, cos, radians
 

--- a/omero_marshal/encode/encoders/shape.py
+++ b/omero_marshal/encode/encoders/shape.py
@@ -47,8 +47,11 @@ class Shape201501Encoder(AnnotatableEncoder):
     def set_visible(self, v, obj):
         self.set_if_not_none(v, 'Visible', obj.visibility)
 
-    @staticmethod
-    def encode_transform(transform):
+    def get_transform_type(self):
+        return 'http://www.openmicroscopy.org/Schemas/ROI/2015-01' \
+            '#AffineTransform'
+
+    def encode_transform(self, transform):
         transform = unwrap(transform)
         if not transform or transform == 'none':
             return
@@ -80,8 +83,7 @@ class Shape201501Encoder(AnnotatableEncoder):
             raise ValueError('Unknown transformation "%s"' % transform)
 
         return {
-            '@type': 'http://www.openmicroscopy.org/Schemas/ROI/2015-01'
-                     '#AffineTransform',
+            '@type': self.get_transform_type(),
             'A00': a[0],
             'A10': a[1],
             'A01': a[2],
@@ -100,6 +102,10 @@ class Shape201606Encoder(Shape201501Encoder):
 
     def set_visible(self, v, obj):
         pass
+
+    def get_transform_type(self):
+        return 'http://www.openmicroscopy.org/Schemas/OME/2016-06' \
+            '#AffineTransform'
 
 
 if SCHEMA_VERSION == '2015-01':

--- a/omero_marshal/encode/encoders/shape.py
+++ b/omero_marshal/encode/encoders/shape.py
@@ -11,7 +11,7 @@
 
 from .annotation import AnnotatableEncoder
 from omero.model import Shape
-from omero_marshal import get_schema_version
+from omero_marshal import SCHEMA_VERSION
 
 
 class ShapeEncoder(AnnotatableEncoder):
@@ -33,7 +33,7 @@ class ShapeEncoder(AnnotatableEncoder):
         self.set_if_not_none(v, 'TheC', obj.theC)
         self.set_if_not_none(v, 'TheT', obj.theT)
         self.set_if_not_none(v, 'TheZ', obj.theZ)
-        if get_schema_version() == '2015-01':
+        if SCHEMA_VERSION == '2015-01':
             self.set_if_not_none(v, 'LineCap', obj.strokeLineCap)
             self.set_if_not_none(v, 'Visible', obj.visibility)
         return v

--- a/omero_marshal/encode/encoders/tag_annotation.py
+++ b/omero_marshal/encode/encoders/tag_annotation.py
@@ -9,17 +9,29 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .text_annotation import TextAnnotationEncoder
 from omero.model import TagAnnotationI
 
 
-class TagAnnotationEncoder(TextAnnotationEncoder):
+class TagAnnotation201501Encoder(TextAnnotationEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#TagAnnotation'
 
     def encode(self, obj):
-        v = super(TagAnnotationEncoder, self).encode(obj)
+        v = super(TagAnnotation201501Encoder, self).encode(obj)
         return v
 
-encoder = (TagAnnotationI, TagAnnotationEncoder)
+
+class TagAnnotation201606Encoder(TagAnnotation201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06' \
+        '#TagAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (TagAnnotationI, TagAnnotation201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (TagAnnotationI, TagAnnotation201606Encoder)
+TagAnnotationEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/term_annotation.py
+++ b/omero_marshal/encode/encoders/term_annotation.py
@@ -9,18 +9,30 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotationEncoder
 from omero.model import TermAnnotationI
 
 
-class TermAnnotationEncoder(AnnotationEncoder):
+class TermAnnotation201501Encoder(AnnotationEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#TermAnnotation'
 
     def encode(self, obj):
-        v = super(TermAnnotationEncoder, self).encode(obj)
+        v = super(TermAnnotation201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'Value', obj.termValue)
         return v
 
-encoder = (TermAnnotationI, TermAnnotationEncoder)
+
+class TermAnnotation201606Encoder(TermAnnotation201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06' \
+        '#TermAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (TermAnnotationI, TermAnnotation201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (TermAnnotationI, TermAnnotation201606Encoder)
+TermAnnotationEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/text_annotation.py
+++ b/omero_marshal/encode/encoders/text_annotation.py
@@ -9,18 +9,30 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotationEncoder
 from omero.model import TextAnnotation
 
 
-class TextAnnotationEncoder(AnnotationEncoder):
+class TextAnnotation201501Encoder(AnnotationEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#TextAnnotation'
 
     def encode(self, obj):
-        v = super(TextAnnotationEncoder, self).encode(obj)
+        v = super(TextAnnotation201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'Value', obj.textValue)
         return v
 
-encoder = (TextAnnotation, TextAnnotationEncoder)
+
+class TextAnnotation201606Encoder(TextAnnotation201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06' \
+        '#TextAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (TextAnnotation, TextAnnotation201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (TextAnnotation, TextAnnotation201606Encoder)
+TextAnnotationEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/timestamp_annotation.py
+++ b/omero_marshal/encode/encoders/timestamp_annotation.py
@@ -9,18 +9,30 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .annotation import AnnotationEncoder
 from omero.model import TimestampAnnotationI
 
 
-class TimestampAnnotationEncoder(AnnotationEncoder):
+class TimestampAnnotation201501Encoder(AnnotationEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#TimestampAnnotation'
 
     def encode(self, obj):
-        v = super(TimestampAnnotationEncoder, self).encode(obj)
+        v = super(TimestampAnnotation201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'Value', obj.timeValue)
         return v
 
-encoder = (TimestampAnnotationI, TimestampAnnotationEncoder)
+
+class TimestampAnnotation201606Encoder(TimestampAnnotation201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06' \
+        '#TimestampAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (TimestampAnnotationI, TimestampAnnotation201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (TimestampAnnotationI, TimestampAnnotation201606Encoder)
+TimestampAnnotationEncoder = encoder[1]

--- a/omero_marshal/encode/encoders/xml_annotation.py
+++ b/omero_marshal/encode/encoders/xml_annotation.py
@@ -9,17 +9,29 @@
 # jason@glencoesoftware.com.
 #
 
+from ... import SCHEMA_VERSION
 from .text_annotation import TextAnnotationEncoder
 from omero.model import XmlAnnotationI
 
 
-class XmlAnnotationEncoder(TextAnnotationEncoder):
+class XmlAnnotation201501Encoder(TextAnnotationEncoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/SA/2015-01' \
         '#XmlAnnotation'
 
     def encode(self, obj):
-        v = super(XmlAnnotationEncoder, self).encode(obj)
+        v = super(XmlAnnotation201501Encoder, self).encode(obj)
         return v
 
-encoder = (XmlAnnotationI, XmlAnnotationEncoder)
+
+class XmlAnnotation201606Encoder(XmlAnnotation201501Encoder):
+
+    TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06' \
+        '#XmlAnnotation'
+
+
+if SCHEMA_VERSION == '2015-01':
+    encoder = (XmlAnnotationI, XmlAnnotation201501Encoder)
+elif SCHEMA_VERSION == '2016-06':
+    encoder = (XmlAnnotationI, XmlAnnotation201606Encoder)
+XmlAnnotationEncoder = encoder[1]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -247,8 +247,8 @@ def ellipse():
     populate_shape(o)
     o.x = rdouble(1.0)
     o.y = rdouble(2.0)
-    o.radiusx = rdouble(3.0)
-    o.radiusy = rdouble(4.0)
+    o.radiusX = rdouble(3.0)
+    o.radiusY = rdouble(4.0)
     o.id = rlong(1L)
     return o
 
@@ -260,8 +260,8 @@ def ellipse_with_annotations():
     add_annotations(o)
     o.x = rdouble(1.0)
     o.y = rdouble(2.0)
-    o.radiusx = rdouble(3.0)
-    o.radiusy = rdouble(4.0)
+    o.radiusX = rdouble(3.0)
+    o.radiusY = rdouble(4.0)
     o.id = rlong(1L)
     return o
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -27,6 +27,8 @@ except ImportError:
     # OMERO 5.2.x
     from omero.model import RectangleI
 
+from omero_marshal import get_schema_version
+
 
 @pytest.fixture()
 def project():
@@ -245,24 +247,24 @@ def populate_shape(o, set_unit_attributes=True):
 def ellipse():
     o = EllipseI()
     populate_shape(o)
-    o.x = rdouble(1.0)
-    o.y = rdouble(2.0)
-    o.radiusX = rdouble(3.0)
-    o.radiusY = rdouble(4.0)
+    if get_schema_version() == '2015-01':
+        o.cx = rdouble(1.0)
+        o.cy = rdouble(2.0)
+        o.rx = rdouble(3.0)
+        o.ry = rdouble(4.0)
+    else:
+        o.x = rdouble(1.0)
+        o.y = rdouble(2.0)
+        o.radiusX = rdouble(3.0)
+        o.radiusY = rdouble(4.0)
     o.id = rlong(1L)
     return o
 
 
 @pytest.fixture()
 def ellipse_with_annotations():
-    o = EllipseI()
-    populate_shape(o)
+    o = ellipse()
     add_annotations(o)
-    o.x = rdouble(1.0)
-    o.y = rdouble(2.0)
-    o.radiusX = rdouble(3.0)
-    o.radiusY = rdouble(4.0)
-    o.id = rlong(1L)
     return o
 
 
@@ -282,8 +284,12 @@ def rectangle():
 def point():
     o = PointI()
     populate_shape(o)
-    o.x = rdouble(1.0)
-    o.y = rdouble(2.0)
+    if get_schema_version() == '2015-01':
+        o.cx = rdouble(1.0)
+        o.cy = rdouble(2.0)
+    else:
+        o.x = rdouble(1.0)
+        o.y = rdouble(2.0)
     o.id = rlong(3L)
     return o
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -245,10 +245,10 @@ def populate_shape(o, set_unit_attributes=True):
 def ellipse():
     o = EllipseI()
     populate_shape(o)
-    o.cx = rdouble(1.0)
-    o.cy = rdouble(2.0)
-    o.rx = rdouble(3.0)
-    o.ry = rdouble(4.0)
+    o.x = rdouble(1.0)
+    o.y = rdouble(2.0)
+    o.radiusx = rdouble(3.0)
+    o.radiusy = rdouble(4.0)
     o.id = rlong(1L)
     return o
 
@@ -258,10 +258,10 @@ def ellipse_with_annotations():
     o = EllipseI()
     populate_shape(o)
     add_annotations(o)
-    o.cx = rdouble(1.0)
-    o.cy = rdouble(2.0)
-    o.rx = rdouble(3.0)
-    o.ry = rdouble(4.0)
+    o.x = rdouble(1.0)
+    o.y = rdouble(2.0)
+    o.radiusx = rdouble(3.0)
+    o.radiusy = rdouble(4.0)
     o.id = rlong(1L)
     return o
 
@@ -282,8 +282,8 @@ def rectangle():
 def point():
     o = PointI()
     populate_shape(o)
-    o.cx = rdouble(1.0)
-    o.cy = rdouble(2.0)
+    o.x = rdouble(1.0)
+    o.y = rdouble(2.0)
     o.id = rlong(3L)
     return o
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -254,7 +254,17 @@ def populate_shape(o, set_unit_attributes=True):
     o.theC = rint(1)
     o.theT = rint(2)
     o.theZ = rint(3)
-    o.transform = 'matrix(1 0 0 1 0 0)'
+    if SCHEMA_VERSION == '2015-01':
+        o.transform = 'matrix(1 0 0 1 0 0)'
+    else:
+        from omero.model import AffineTransformI
+        o.transform = AffineTransformI()
+        o.transform.setA00(rdouble(1))
+        o.transform.setA10(rdouble(0))
+        o.transform.setA01(rdouble(0))
+        o.transform.setA11(rdouble(1))
+        o.transform.setA02(rdouble(0))
+        o.transform.setA12(rdouble(0))
     return o
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -27,7 +27,7 @@ except ImportError:
     # OMERO 5.2.x
     from omero.model import RectangleI
 
-from omero_marshal import get_schema_version
+from omero_marshal import SCHEMA_VERSION
 
 
 @pytest.fixture()
@@ -232,7 +232,7 @@ def populate_shape(o, set_unit_attributes=True):
     o.locked = rbool(False)
     o.strokeColor = rint(0xffff0000)
     o.strokeDashArray = rstring('inherit')
-    if get_schema_version() == '2015-01':
+    if SCHEMA_VERSION == '2015-01':
         o.visibility = rbool(True)
         o.strokeLineCap = rstring('round')
     if set_unit_attributes:
@@ -248,7 +248,7 @@ def populate_shape(o, set_unit_attributes=True):
 def ellipse():
     o = EllipseI()
     populate_shape(o)
-    if get_schema_version() == '2015-01':
+    if SCHEMA_VERSION == '2015-01':
         o.cx = rdouble(1.0)
         o.cy = rdouble(2.0)
         o.rx = rdouble(3.0)
@@ -285,7 +285,7 @@ def rectangle():
 def point():
     o = PointI()
     populate_shape(o)
-    if get_schema_version() == '2015-01':
+    if SCHEMA_VERSION == '2015-01':
         o.cx = rdouble(1.0)
         o.cy = rdouble(2.0)
     else:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -232,14 +232,15 @@ def populate_shape(o, set_unit_attributes=True):
     o.locked = rbool(False)
     o.strokeColor = rint(0xffff0000)
     o.strokeDashArray = rstring('inherit')
-    o.strokeLineCap = rstring('round')
+    if get_schema_version() == '2015-01':
+        o.visibility = rbool(True)
+        o.strokeLineCap = rstring('round')
     if set_unit_attributes:
         o.strokeWidth = LengthI(4, UnitsLength.PIXEL)
     o.textValue = rstring('the_text')
     o.theC = rint(1)
     o.theT = rint(2)
     o.theZ = rint(3)
-    o.visibility = rbool(True)
     return o
 
 

--- a/tests/unit/test_base_decoder.py
+++ b/tests/unit/test_base_decoder.py
@@ -12,7 +12,7 @@
 import json
 
 from omero.model import RoiI
-from omero_marshal import get_encoder, get_decoder
+from omero_marshal import get_encoder, get_decoder, ROI_SCHEMA_URL
 
 
 class TestBaseDecoder(object):
@@ -34,11 +34,11 @@ class TestBaseDecoder(object):
 
     def test_base_decoder_from_string(self):
         data_as_string = """{
-    "@type": "http://www.openmicroscopy.org/Schemas/ROI/2015-01#ROI",
+    "@type": "%s#ROI",
     "@id": 1,
     "Name": "the_name",
     "Description": "the_description"
-}"""
+}""" % ROI_SCHEMA_URL
         data = json.loads(data_as_string)
         decoder = get_decoder(data['@type'])
         v = decoder.decode(data)

--- a/tests/unit/test_base_encoder.py
+++ b/tests/unit/test_base_encoder.py
@@ -9,7 +9,7 @@
 # jason@glencoesoftware.com.
 #
 
-from omero_marshal import get_encoder, ROI_SCHEMA_URL
+from omero_marshal import get_encoder, ROI_SCHEMA_URL, OME_SCHEMA_URL
 
 
 class TestBaseEncoder(object):
@@ -26,18 +26,14 @@ class TestBaseEncoder(object):
                 '@type': 'TBD#Details',
                 'group': {
                     '@id': 1L,
-                    '@type':
-                        'http://www.openmicroscopy.org/Schemas/OME/2015-01'
-                        '#ExperimenterGroup',
+                    '@type': '%s#ExperimenterGroup' % OME_SCHEMA_URL,
                     'Description': 'the_description',
                     'Name': 'the_name',
                     'omero:details': {'@type': 'TBD#Details'}
                 },
                 'owner': {
                     '@id': 1L,
-                    '@type':
-                        'http://www.openmicroscopy.org/Schemas/OME/2015-01'
-                        '#Experimenter',
+                    '@type': '%s#Experimenter' % OME_SCHEMA_URL,
                     'Email': 'the_email',
                     'FirstName': 'the_firstName',
                     'Institution': 'the_institution',
@@ -70,15 +66,11 @@ class TestBaseEncoder(object):
                 '@type': 'TBD#Details',
                 'owner': {
                     '@id': 1L,
-                    '@type':
-                        'http://www.openmicroscopy.org/Schemas/OME/2015-01'
-                        '#Experimenter'
+                    '@type': '%s#Experimenter' % OME_SCHEMA_URL
                 },
                 'group': {
                     '@id': 1L,
-                    '@type':
-                        'http://www.openmicroscopy.org/Schemas/OME/2015-01'
-                        '#ExperimenterGroup'
+                    '@type': '%s#ExperimenterGroup' % OME_SCHEMA_URL
                 },
                 'permissions': {
                     '@type': 'TBD#Permissions',
@@ -97,9 +89,7 @@ class TestDetailsEncoder(object):
     def experimenter_json(self):
         return {
             '@id': 1L,
-            '@type':
-                'http://www.openmicroscopy.org/Schemas/OME/2015-01'
-                '#Experimenter',
+            '@type': '%s#Experimenter' % OME_SCHEMA_URL,
             'FirstName': 'the_firstName',
             'MiddleName': 'the_middleName',
             'LastName': 'the_lastName',
@@ -117,9 +107,7 @@ class TestDetailsEncoder(object):
     def experimenter_group_json(self):
         return {
             '@id': 1L,
-            '@type':
-                'http://www.openmicroscopy.org/Schemas/OME/2015-01'
-                '#ExperimenterGroup',
+            '@type': '%s#ExperimenterGroup' % OME_SCHEMA_URL,
             'Name': 'the_name',
             'Description': 'the_description',
             'omero:details': {'@type': 'TBD#Details'}

--- a/tests/unit/test_base_encoder.py
+++ b/tests/unit/test_base_encoder.py
@@ -9,7 +9,7 @@
 # jason@glencoesoftware.com.
 #
 
-from omero_marshal import get_encoder
+from omero_marshal import get_encoder, ROI_SCHEMA_URL
 
 
 class TestBaseEncoder(object):
@@ -19,7 +19,7 @@ class TestBaseEncoder(object):
         v = encoder.encode(roi)
         assert v == {
             '@id': 1L,
-            '@type': 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#ROI',
+            '@type': '%s#ROI' % ROI_SCHEMA_URL,
             'Name': 'the_name',
             'Description': 'the_description',
             'omero:details': {
@@ -63,7 +63,7 @@ class TestBaseEncoder(object):
         v = encoder.encode(roi_with_unloaded_details_children)
         assert v == {
             '@id': 1L,
-            '@type': 'http://www.openmicroscopy.org/Schemas/ROI/2015-01#ROI',
+            '@type': '%s#ROI' % ROI_SCHEMA_URL,
             'Name': 'the_name',
             'Description': 'the_description',
             'omero:details': {

--- a/tests/unit/test_container_encoders.py
+++ b/tests/unit/test_container_encoders.py
@@ -9,7 +9,7 @@
 # jason@glencoesoftware.com.
 #
 
-from omero_marshal import get_encoder
+from omero_marshal import get_encoder, OME_SCHEMA_URL
 
 
 class TestProjectEncoder(object):
@@ -19,8 +19,7 @@ class TestProjectEncoder(object):
         v = encoder.encode(project)
         assert v == {
             '@id': 1L,
-            '@type':
-                'http://www.openmicroscopy.org/Schemas/OME/2015-01#Project',
+            '@type': '%s#Project' % OME_SCHEMA_URL,
             'Name': 'the_name',
             'Description': 'the_description',
             'omero:details': {'@type': 'TBD#Details'}
@@ -31,24 +30,19 @@ class TestProjectEncoder(object):
         v = encoder.encode(project_with_datasets)
         assert v == {
             '@id': 1L,
-            '@type':
-                'http://www.openmicroscopy.org/Schemas/OME/2015-01#Project',
+            '@type': '%s#Project' % OME_SCHEMA_URL,
             'Name': 'the_name',
             'Description': 'the_description',
             'omero:details': {'@type': 'TBD#Details'},
             'Datasets': [{
                 '@id': 1L,
-                '@type':
-                    'http://www.openmicroscopy.org/Schemas/OME/2015-01'
-                    '#Dataset',
+                '@type': '%s#Dataset' % OME_SCHEMA_URL,
                 'Name': 'dataset_name_1',
                 'Description': 'dataset_description_1',
                 'omero:details': {'@type': 'TBD#Details'}
             }, {
                 '@id': 2L,
-                '@type':
-                    'http://www.openmicroscopy.org/Schemas/OME/2015-01'
-                    '#Dataset',
+                '@type': '%s#Dataset' % OME_SCHEMA_URL,
                 'Name': 'dataset_name_2',
                 'Description': 'dataset_description_2',
                 'omero:details': {'@type': 'TBD#Details'}

--- a/tests/unit/test_register_decoder.py
+++ b/tests/unit/test_register_decoder.py
@@ -9,13 +9,11 @@
 # jason@glencoesoftware.com.
 #
 
-from omero_marshal import get_decoder
+from omero_marshal import get_decoder, ROI_SCHEMA_URL
 
 
 class TestRegisterDecoder(object):
 
     def test_roi_decoder_registered(self):
-        decoder = get_decoder(
-            'http://www.openmicroscopy.org/Schemas/ROI/2015-01#ROI'
-        )
+        decoder = get_decoder('%s#ROI' % ROI_SCHEMA_URL)
         assert decoder is not None

--- a/tests/unit/test_schema_version.py
+++ b/tests/unit/test_schema_version.py
@@ -31,3 +31,15 @@ SFS = (SchemaFixture("5.1.0-ice35-b40", "2015-01"),
 @pytest.mark.parametrize("f", SFS, ids=[x.omero_version for x in SFS])
 def test_schema_version(f):
     assert get_schema_version(f.omero_version) == f.schema_version
+
+
+def test_invalid_omero_version():
+    with pytest.raises(Exception) as excinfo:
+        get_schema_version("5.0")
+    assert str(excinfo.value) == "Invalid OMERO version number 5.0"
+
+
+def test_invalid_schema_version():
+    with pytest.raises(Exception) as excinfo:
+        get_schema_version("5.0.0")
+    assert str(excinfo.value) == "Unsupported schema version"

--- a/tests/unit/test_schema_version.py
+++ b/tests/unit/test_schema_version.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016, Inc. All rights reserved.
+#
+# This software is distributed under the terms described by the LICENCE file
+# you can find at the root of the distribution bundle.
+# If the file is missing please request a copy by contacting
+# jason@glencoesoftware.com.
+#
+
+from omero_marshal import get_schema_version
+import pytest
+
+
+class SchemaFixture(object):
+    """
+    Fixture to test matching of omero version and schema version
+    """
+
+    def __init__(self, omero_version, schema_version):
+        self.omero_version = omero_version
+        self.schema_version = schema_version
+
+SFS = (SchemaFixture("5.1.0-ice35-b40", "2015-01"),
+       SchemaFixture("5.2.0-ice35-b12", "2015-01"),
+       SchemaFixture("5.2.4-ice35-b23", "2015-01"),
+       SchemaFixture("5.3.0-m2-ice35-b20", "2016-06"))
+
+
+@pytest.mark.parametrize("f", SFS, ids=[x.omero_version for x in SFS])
+def test_schema_version(f):
+    assert get_schema_version(f.omero_version) == f.schema_version

--- a/tests/unit/test_schema_version.py
+++ b/tests/unit/test_schema_version.py
@@ -32,14 +32,15 @@ SFS = (SchemaFixture("5.1.0-ice35-b40", "2015-01"),
 def test_schema_version(f):
     assert get_schema_version(f.omero_version) == f.schema_version
 
-
-def test_invalid_omero_version():
+@pytest.mark.parametrize('version', ('5', '5.1', 'v5.1.0'))
+def test_invalid_omero_version(version):
     with pytest.raises(Exception) as excinfo:
-        get_schema_version("5.0")
-    assert str(excinfo.value) == "Invalid OMERO version number 5.0"
+        get_schema_version(version)
+    assert str(excinfo.value) == "Invalid OMERO version number: %s" % version
 
 
-def test_invalid_schema_version():
+@pytest.mark.parametrize('version', ('5.0.0', '5.0.1'))
+def test_invalid_schema_version(version):
     with pytest.raises(Exception) as excinfo:
-        get_schema_version("5.0.0")
-    assert str(excinfo.value) == "Unsupported schema version"
+        get_schema_version(version)
+    assert str(excinfo.value) == "Unsupported OMERO version: %s" % version

--- a/tests/unit/test_schema_version.py
+++ b/tests/unit/test_schema_version.py
@@ -32,6 +32,7 @@ SFS = (SchemaFixture("5.1.0-ice35-b40", "2015-01"),
 def test_schema_version(f):
     assert get_schema_version(f.omero_version) == f.schema_version
 
+
 @pytest.mark.parametrize('version', ('5', '5.1', 'v5.1.0'))
 def test_invalid_omero_version(version):
     with pytest.raises(Exception) as excinfo:

--- a/tests/unit/test_shape_decoders.py
+++ b/tests/unit/test_shape_decoders.py
@@ -158,7 +158,6 @@ class TestEllipseDecoder(TestShapeDecoder):
     def test_decoder(self, ellipse):
         encoder = get_encoder(ellipse.__class__)
         decoder = get_decoder(encoder.TYPE)
-        print encoder.TYPE
         v = encoder.encode(ellipse)
         v = decoder.decode(v)
         self.assert_ellipse(v)

--- a/tests/unit/test_shape_decoders.py
+++ b/tests/unit/test_shape_decoders.py
@@ -118,14 +118,14 @@ class TestShapeDecoder(object):
     def assert_ellipse(self, ellipse, has_annotations=False):
         self.assert_shape(ellipse, has_annotations=has_annotations)
         assert ellipse.id.val == 1L
-        assert ellipse.cx.__class__ is RDoubleI
-        assert ellipse.cx.val == 1.0
-        assert ellipse.cy.__class__ is RDoubleI
-        assert ellipse.cy.val == 2.0
-        assert ellipse.rx.__class__ is RDoubleI
-        assert ellipse.rx.val == 3.0
-        assert ellipse.ry.__class__ is RDoubleI
-        assert ellipse.ry.val == 4.0
+        assert ellipse.x.__class__ is RDoubleI
+        assert ellipse.x.val == 1.0
+        assert ellipse.y.__class__ is RDoubleI
+        assert ellipse.y.val == 2.0
+        assert ellipse.radiusx.__class__ is RDoubleI
+        assert ellipse.radiusx.val == 3.0
+        assert ellipse.radiusy.__class__ is RDoubleI
+        assert ellipse.radiusy.val == 4.0
 
     def assert_rectangle(self, rectangle):
         self.assert_shape(rectangle)
@@ -176,10 +176,10 @@ class TestPointDecoder(TestShapeDecoder):
         v = decoder.decode(v)
         self.assert_shape(v)
         assert v.id.val == 3L
-        assert v.cx.__class__ is RDoubleI
-        assert v.cx.val == 1.0
-        assert v.cy.__class__ is RDoubleI
-        assert v.cy.val == 2.0
+        assert v.x.__class__ is RDoubleI
+        assert v.x.val == 1.0
+        assert v.y.__class__ is RDoubleI
+        assert v.y.val == 2.0
 
 
 class TestLabelDecoder(TestShapeDecoder):

--- a/tests/unit/test_shape_decoders.py
+++ b/tests/unit/test_shape_decoders.py
@@ -119,7 +119,17 @@ class TestShapeDecoder(object):
         assert shape.theZ.val == 3
         assert shape.theT.val == 2
         assert shape.theC.val == 1
-        assert shape.transform.val == 'matrix(1.0 0.0 0.0 1.0 0.0 0.0)'
+        if SCHEMA_VERSION == '2015-01':
+            assert shape.transform.val == 'matrix(1.0 0.0 0.0 1.0 0.0 0.0)'
+        else:
+            from omero.model import AffineTransformI
+            assert shape.transform.__class__ is AffineTransformI
+            assert shape.transform.getA00().val == 1.0
+            assert shape.transform.getA10().val == 0.0
+            assert shape.transform.getA01().val == 0.0
+            assert shape.transform.getA11().val == 1.0
+            assert shape.transform.getA02().val == 0.0
+            assert shape.transform.getA12().val == 0.0
         if not has_annotations:
             assert not shape.annotationLinksLoaded
         else:
@@ -354,7 +364,8 @@ TRANSFORMATIONS = [
 ]
 
 
-class TestTransformDecoder():
+@pytest.mark.skipif(SCHEMA_VERSION != "2015-01", reason="old model")
+class TestTransform201501Decoder():
 
     @pytest.mark.parametrize("transform_s,transform_o", TRANSFORMATIONS)
     def test_transforms(self, point, transform_s, transform_o):

--- a/tests/unit/test_shape_decoders.py
+++ b/tests/unit/test_shape_decoders.py
@@ -95,8 +95,6 @@ class TestShapeDecoder(object):
             assert shape.strokeWidth.getValue() == 4
         else:
             assert shape.strokeWidth is None
-
-        assert shape.strokeLineCap.val == 'round'
         assert shape.textValue.val == 'the_text'
         assert shape.fontFamily.val == 'cursive'
         if has_unit_information:
@@ -106,7 +104,9 @@ class TestShapeDecoder(object):
         else:
             assert shape.fontSize is None
         assert shape.fontStyle.val == 'italic'
-        assert shape.visibility.val is True
+        if get_schema_version() == '2016-06':
+            assert shape.visibility.val is True
+            assert shape.strokeLineCap.val == 'round'
         assert shape.locked.val is False
         assert shape.theZ.val == 3
         assert shape.theT.val == 2

--- a/tests/unit/test_shape_decoders.py
+++ b/tests/unit/test_shape_decoders.py
@@ -122,10 +122,10 @@ class TestShapeDecoder(object):
         assert ellipse.x.val == 1.0
         assert ellipse.y.__class__ is RDoubleI
         assert ellipse.y.val == 2.0
-        assert ellipse.radiusx.__class__ is RDoubleI
-        assert ellipse.radiusx.val == 3.0
-        assert ellipse.radiusy.__class__ is RDoubleI
-        assert ellipse.radiusy.val == 4.0
+        assert ellipse.radiusX.__class__ is RDoubleI
+        assert ellipse.radiusX.val == 3.0
+        assert ellipse.radiusY.__class__ is RDoubleI
+        assert ellipse.radiusY.val == 4.0
 
     def assert_rectangle(self, rectangle):
         self.assert_shape(rectangle)

--- a/tests/unit/test_shape_decoders.py
+++ b/tests/unit/test_shape_decoders.py
@@ -158,6 +158,7 @@ class TestEllipseDecoder(TestShapeDecoder):
     def test_decoder(self, ellipse):
         encoder = get_encoder(ellipse.__class__)
         decoder = get_decoder(encoder.TYPE)
+        print encoder.TYPE
         v = encoder.encode(ellipse)
         v = decoder.decode(v)
         self.assert_ellipse(v)

--- a/tests/unit/test_shape_decoders.py
+++ b/tests/unit/test_shape_decoders.py
@@ -9,7 +9,7 @@
 # jason@glencoesoftware.com.
 #
 
-from omero_marshal import get_encoder, get_decoder, get_schema_version
+from omero_marshal import get_encoder, get_decoder, SCHEMA_VERSION
 from omero.model.enums import UnitsLength
 from omero.rtypes import RDoubleI
 from omero.model import LengthI
@@ -104,7 +104,7 @@ class TestShapeDecoder(object):
         else:
             assert shape.fontSize is None
         assert shape.fontStyle.val == 'italic'
-        if get_schema_version() == '2015-01':
+        if SCHEMA_VERSION == '2015-01':
             assert shape.visibility.val is True
             assert shape.strokeLineCap.val == 'round'
         assert shape.locked.val is False
@@ -119,7 +119,7 @@ class TestShapeDecoder(object):
     def assert_ellipse(self, ellipse, has_annotations=False):
         self.assert_shape(ellipse, has_annotations=has_annotations)
         assert ellipse.id.val == 1L
-        if get_schema_version() == '2016-06':
+        if SCHEMA_VERSION == '2016-06':
             assert ellipse.x.__class__ is RDoubleI
             assert ellipse.x.val == 1.0
             assert ellipse.y.__class__ is RDoubleI
@@ -187,7 +187,7 @@ class TestPointDecoder(TestShapeDecoder):
         v = decoder.decode(v)
         self.assert_shape(v)
         assert v.id.val == 3L
-        if get_schema_version() == '2016-06':
+        if SCHEMA_VERSION == '2016-06':
             assert v.x.__class__ is RDoubleI
             assert v.x.val == 1.0
             assert v.y.__class__ is RDoubleI

--- a/tests/unit/test_shape_decoders.py
+++ b/tests/unit/test_shape_decoders.py
@@ -9,7 +9,7 @@
 # jason@glencoesoftware.com.
 #
 
-from omero_marshal import get_encoder, get_decoder
+from omero_marshal import get_encoder, get_decoder, get_schema_version
 from omero.model.enums import UnitsLength
 from omero.rtypes import RDoubleI
 from omero.model import LengthI
@@ -83,7 +83,8 @@ class TestShapeDecoder(object):
             self.assert_annotations(roi)
         self.assert_details(roi.details)
 
-    def assert_shape(self, shape, has_annotations=False, has_unit_information=True):
+    def assert_shape(self, shape, has_annotations=False,
+                     has_unit_information=True):
         assert shape.fillColor.val == 0xffffffff
         assert shape.fillRule.val == 'solid'
         assert shape.strokeColor.val == 0xffff0000
@@ -118,14 +119,24 @@ class TestShapeDecoder(object):
     def assert_ellipse(self, ellipse, has_annotations=False):
         self.assert_shape(ellipse, has_annotations=has_annotations)
         assert ellipse.id.val == 1L
-        assert ellipse.x.__class__ is RDoubleI
-        assert ellipse.x.val == 1.0
-        assert ellipse.y.__class__ is RDoubleI
-        assert ellipse.y.val == 2.0
-        assert ellipse.radiusX.__class__ is RDoubleI
-        assert ellipse.radiusX.val == 3.0
-        assert ellipse.radiusY.__class__ is RDoubleI
-        assert ellipse.radiusY.val == 4.0
+        if get_schema_version() == '2016-06':
+            assert ellipse.x.__class__ is RDoubleI
+            assert ellipse.x.val == 1.0
+            assert ellipse.y.__class__ is RDoubleI
+            assert ellipse.y.val == 2.0
+            assert ellipse.radiusX.__class__ is RDoubleI
+            assert ellipse.radiusX.val == 3.0
+            assert ellipse.radiusY.__class__ is RDoubleI
+            assert ellipse.radiusY.val == 4.0
+        else:
+            assert ellipse.cx.__class__ is RDoubleI
+            assert ellipse.cx.val == 1.0
+            assert ellipse.cy.__class__ is RDoubleI
+            assert ellipse.cy.val == 2.0
+            assert ellipse.rx.__class__ is RDoubleI
+            assert ellipse.rx.val == 3.0
+            assert ellipse.ry.__class__ is RDoubleI
+            assert ellipse.ry.val == 4.0
 
     def assert_rectangle(self, rectangle):
         self.assert_shape(rectangle)
@@ -176,10 +187,16 @@ class TestPointDecoder(TestShapeDecoder):
         v = decoder.decode(v)
         self.assert_shape(v)
         assert v.id.val == 3L
-        assert v.x.__class__ is RDoubleI
-        assert v.x.val == 1.0
-        assert v.y.__class__ is RDoubleI
-        assert v.y.val == 2.0
+        if get_schema_version() == '2016-06':
+            assert v.x.__class__ is RDoubleI
+            assert v.x.val == 1.0
+            assert v.y.__class__ is RDoubleI
+            assert v.y.val == 2.0
+        else:
+            assert v.cx.__class__ is RDoubleI
+            assert v.cx.val == 1.0
+            assert v.cy.__class__ is RDoubleI
+            assert v.cy.val == 2.0
 
 
 class TestLabelDecoder(TestShapeDecoder):
@@ -263,6 +280,7 @@ class TestRoiDecoder(TestShapeDecoder):
         v = encoder.encode(roi_with_shapes_and_annotations)
         v = decoder.decode(v)
         self.assert_roi_with_shapes(v, has_annotations=True)
+
 
 class TestOptionalUnitInformation(TestShapeDecoder):
 

--- a/tests/unit/test_shape_decoders.py
+++ b/tests/unit/test_shape_decoders.py
@@ -104,7 +104,7 @@ class TestShapeDecoder(object):
         else:
             assert shape.fontSize is None
         assert shape.fontStyle.val == 'italic'
-        if get_schema_version() == '2016-06':
+        if get_schema_version() == '2015-01':
             assert shape.visibility.val is True
             assert shape.strokeLineCap.val == 'round'
         assert shape.locked.val is False

--- a/tests/unit/test_shape_encoders.py
+++ b/tests/unit/test_shape_encoders.py
@@ -9,7 +9,7 @@
 # jason@glencoesoftware.com.
 #
 
-from omero_marshal import get_encoder
+from omero_marshal import get_encoder, get_schema_version
 
 
 class TestShapeEncoder(object):
@@ -140,7 +140,6 @@ class TestShapeEncoder(object):
             'Symbol': 'pixel',
             'Value': 4
         }
-        assert shape['LineCap'] == 'round'
         assert shape['Text'] == 'the_text'
         assert shape['FontFamily'] == 'cursive'
         assert shape['FontSize'] == {
@@ -150,7 +149,9 @@ class TestShapeEncoder(object):
             'Value': 12
         }
         assert shape['FontStyle'] == 'italic'
-        assert shape['Visible'] is True
+        if get_schema_version() == '2015-01':
+            assert shape['LineCap'] == 'round'
+            assert shape['Visible'] is True
         assert shape['Locked'] is False
         assert shape['TheZ'] == 3
         assert shape['TheT'] == 2

--- a/tests/unit/test_shape_encoders.py
+++ b/tests/unit/test_shape_encoders.py
@@ -9,7 +9,7 @@
 # jason@glencoesoftware.com.
 #
 
-from omero_marshal import get_encoder, get_schema_version
+from omero_marshal import get_encoder, SCHEMA_VERSION
 
 
 class TestShapeEncoder(object):
@@ -149,7 +149,7 @@ class TestShapeEncoder(object):
             'Value': 12
         }
         assert shape['FontStyle'] == 'italic'
-        if get_schema_version() == '2015-01':
+        if SCHEMA_VERSION == '2015-01':
             assert shape['LineCap'] == 'round'
             assert shape['Visible'] is True
         assert shape['Locked'] is False

--- a/tests/unit/test_shape_encoders.py
+++ b/tests/unit/test_shape_encoders.py
@@ -90,8 +90,7 @@ class TestShapeEncoder(object):
         assert roi['@id'] == 1L
         assert roi['Name'] == 'the_name'
         assert roi['Description'] == 'the_description'
-        assert roi['@type'] == \
-            'http://www.openmicroscopy.org/Schemas/ROI/2015-01#ROI'
+        assert roi['@type'] == '%s#ROI' % ROI_SCHEMA_URL
         assert roi['omero:details'] == {
             '@type': 'TBD#Details',
             'group': {
@@ -184,8 +183,7 @@ class TestShapeEncoder(object):
     def assert_rectangle(self, rectangle):
         self.assert_shape(rectangle)
         assert rectangle['@id'] == 2L
-        assert rectangle['@type'] == \
-            'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Rectangle'
+        assert rectangle['@type'] == '%s#Rectangle' % ROI_SCHEMA_URL
         assert rectangle['X'] == 1.0
         assert rectangle['Y'] == 2.0
         assert rectangle['Width'] == 3.0

--- a/tests/unit/test_shape_encoders.py
+++ b/tests/unit/test_shape_encoders.py
@@ -282,8 +282,7 @@ class TestRoiEncoder(TestShapeEncoder):
         self.assert_roi_with_shapes(v, has_annotations=True)
 
 
-TRANSFORMATION_TYPE = 'http://www.openmicroscopy.org/Schemas/ROI/2015-01' \
-    '#AffineTransform'
+TRANSFORMATION_TYPE = '%s#AffineTransform' % ROI_SCHEMA_URL
 
 TRANSFORMATIONS = [
     (

--- a/tests/unit/test_shape_encoders.py
+++ b/tests/unit/test_shape_encoders.py
@@ -431,10 +431,13 @@ else:
             t.setA02(rdouble(a02))
         if a12:
             t.setA12(rdouble(a12))
-        print t
         return t
 
     TRANSFORMATIONS = [
+        (
+            None,
+            None
+        ),
         (
             create_transform(),
             None
@@ -460,7 +463,6 @@ class TestTransformEncoder():
     @pytest.mark.parametrize("transform_s,transform_o", TRANSFORMATIONS)
     def test_transforms(self, point, transform_s, transform_o):
         point.transform = transform_s
-        print point.transform
         encoder = get_encoder(point.__class__)
         v = encoder.encode(point)
         if not transform_o:

--- a/tests/unit/test_shape_encoders.py
+++ b/tests/unit/test_shape_encoders.py
@@ -10,6 +10,7 @@
 #
 
 from omero_marshal import get_encoder, SCHEMA_VERSION, ROI_SCHEMA_URL
+from omero_marshal import SA_SCHEMA_URL
 import pytest
 
 
@@ -18,64 +19,55 @@ class TestShapeEncoder(object):
     def annotation_data(self):
         return {
             'Annotations': [{
-                '@type': 'http://www.openmicroscopy.org/Schemas/SA/2015-01'
-                         '#BooleanAnnotation',
+                '@type': '%s#BooleanAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'boolean_annotation',
                 'Value': True,
                 'omero:details': {'@type': 'TBD#Details'}
             }, {
-                '@type': 'http://www.openmicroscopy.org/Schemas/SA/2015-01'
-                         '#CommentAnnotation',
+                '@type': '%s#CommentAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'comment_annotation',
                 'Value': 'text_value',
                 'omero:details': {'@type': 'TBD#Details'}
             }, {
-                '@type': 'http://www.openmicroscopy.org/Schemas/SA/2015-01'
-                         '#DoubleAnnotation',
+                '@type': '%s#DoubleAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'double_annotation',
                 'Value': 1.0,
                 'omero:details': {'@type': 'TBD#Details'}
             }, {
-                '@type': 'http://www.openmicroscopy.org/Schemas/SA/2015-01'
-                         '#LongAnnotation',
+                '@type': '%s#LongAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'long_annotation',
                 'Value': 1L,
                 'omero:details': {'@type': 'TBD#Details'}
             }, {
-                '@type': 'http://www.openmicroscopy.org/Schemas/SA/2015-01'
-                         '#MapAnnotation',
+                '@type': '%s#MapAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'map_annotation',
                 'Value': [['a', '1'], ['b', '2']],
                 'omero:details': {'@type': 'TBD#Details'}
             }, {
-                '@type': 'http://www.openmicroscopy.org/Schemas/SA/2015-01'
-                         '#TagAnnotation',
+                '@type': '%s#TagAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'tag_annotation',
                 'Value': 'tag_value',
                 'omero:details': {'@type': 'TBD#Details'}
             }, {
-                '@type': 'http://www.openmicroscopy.org/Schemas/SA/2015-01'
-                         '#TermAnnotation',
+                '@type': '%s#TermAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'term_annotation',
                 'Value': 'term_value',
                 'omero:details': {'@type': 'TBD#Details'}
             }, {
-                '@type': 'http://www.openmicroscopy.org/Schemas/SA/2015-01'
-                         '#TimestampAnnotation',
+                '@type': '%s#TimestampAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'timestamp_annotation',
                 'Value': 1L,
                 'omero:details': {'@type': 'TBD#Details'}
             }, {
-                '@type': 'http://www.openmicroscopy.org/Schemas/SA/2015-01'
-                         '#XmlAnnotation',
+                '@type': '%s#XmlAnnotation' % SA_SCHEMA_URL,
                 'Description': 'the_description',
                 'Namespace': 'xml_annotation',
                 'Value': '<xml_value></xml_value>',

--- a/tests/unit/test_shape_encoders.py
+++ b/tests/unit/test_shape_encoders.py
@@ -230,8 +230,7 @@ class TestLabelEncoder(TestShapeEncoder):
         v = encoder.encode(label)
         self.assert_shape(v)
         assert v['@id'] == 7L
-        assert v['@type'] == \
-            'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Label'
+        assert v['@type'] == '%s#Label' % ROI_SCHEMA_URL
         assert v['X'] == 1.0
         assert v['Y'] == 2.0
 
@@ -243,8 +242,7 @@ class TestPolylineEncoder(TestShapeEncoder):
         v = encoder.encode(polyline)
         self.assert_shape(v)
         assert v['@id'] == 4L
-        assert v['@type'] == \
-            'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Polyline'
+        assert v['@type'] == '%s#Polyline' % ROI_SCHEMA_URL
         assert v['Points'] == '0,0 1,2 3,5'
 
 
@@ -255,8 +253,7 @@ class TestPolygonEncoder(TestShapeEncoder):
         v = encoder.encode(polygon)
         self.assert_shape(v)
         assert v['@id'] == 5L
-        assert v['@type'] == \
-            'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Polygon'
+        assert v['@type'] == '%s#Polygon' % ROI_SCHEMA_URL
         assert v['Points'] == '0,0 1,2 3,5'
 
 
@@ -267,8 +264,7 @@ class TestLineEncoder(TestShapeEncoder):
         v = encoder.encode(line)
         self.assert_shape(v)
         assert v['@id'] == 6L
-        assert v['@type'] == \
-            'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Line'
+        assert v['@type'] == '%s#Line' % ROI_SCHEMA_URL
         assert v['X1'] == 0.0
         assert v['Y1'] == 0.0
         assert v['X2'] == 1.0

--- a/tests/unit/test_shape_encoders.py
+++ b/tests/unit/test_shape_encoders.py
@@ -10,7 +10,7 @@
 #
 
 from omero_marshal import get_encoder, SCHEMA_VERSION, ROI_SCHEMA_URL
-from omero_marshal import SA_SCHEMA_URL
+from omero_marshal import SA_SCHEMA_URL, OME_SCHEMA_URL
 import pytest
 
 
@@ -88,8 +88,7 @@ class TestShapeEncoder(object):
             'group': {
                 '@id': 1L,
                 '@type':
-                    'http://www.openmicroscopy.org/Schemas/OME/2015-01'
-                    '#ExperimenterGroup',
+                    '%s#ExperimenterGroup' % OME_SCHEMA_URL,
                 'Description': 'the_description',
                 'Name': 'the_name',
                 'omero:details': {'@type': 'TBD#Details'}
@@ -97,8 +96,7 @@ class TestShapeEncoder(object):
             'owner': {
                 '@id': 1L,
                 '@type':
-                    'http://www.openmicroscopy.org/Schemas/OME/2015-01'
-                    '#Experimenter',
+                    '%s#Experimenter' % OME_SCHEMA_URL,
                 'Email': 'the_email',
                 'FirstName': 'the_firstName',
                 'Institution': 'the_institution',

--- a/tests/unit/test_shape_encoders.py
+++ b/tests/unit/test_shape_encoders.py
@@ -9,7 +9,7 @@
 # jason@glencoesoftware.com.
 #
 
-from omero_marshal import get_encoder, SCHEMA_VERSION
+from omero_marshal import get_encoder, SCHEMA_VERSION, ROI_SCHEMA_URL
 import pytest
 
 
@@ -175,8 +175,7 @@ class TestShapeEncoder(object):
     def assert_ellipse(self, ellipse, has_annotations=False):
         self.assert_shape(ellipse, has_annotations=has_annotations)
         assert ellipse['@id'] == 1L
-        assert ellipse['@type'] == \
-            'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Ellipse'
+        assert ellipse['@type'] == '%s#Ellipse' % ROI_SCHEMA_URL
         assert ellipse['X'] == 1.0
         assert ellipse['Y'] == 2.0
         assert ellipse['RadiusX'] == 3.0
@@ -221,8 +220,7 @@ class TestPointEncoder(TestShapeEncoder):
         v = encoder.encode(point)
         self.assert_shape(v)
         assert v['@id'] == 3L
-        assert v['@type'] == \
-            'http://www.openmicroscopy.org/Schemas/ROI/2015-01#Point'
+        assert v['@type'] == '%s#Point' % ROI_SCHEMA_URL
         assert v['X'] == 1.0
         assert v['Y'] == 2.0
 


### PR DESCRIPTION
See https://trello.com/c/rYdxg3fZ/74-multi-schemas-support-omero-marshal

### Rationale and limitations

As discussed as part of the Web API discussion, we need to have support for multiple OMERO/schema versions  in `omero-marshal`. The current PR is based on the latest released OMERO 5.3 milestone should exercise the logic required to support multiple versions.

### Summary of the changes

- add a `get_schema_version()` utility function in the top-level `__init__.py` allowing to map the model version from the OMERO version
- use `distutils.version.StrictVersion` to define the supported OMERO versions
- define a top-level `SCHEMA_VERSION` constant for the currently used schema that can be used to choose the encoders/decoders at runtime
- implement multi-schema support for all encoders/decoders as follows:
   - define `{Element}{YYYMM}{Encoder,Decoder}` classes where `YYYYMM` is the schema year/month and recent model classes inherit from older model classes
   - override the `TYPE` in the 201606 classes
   - for all breaking changes, refactor encoding/decoding using methods and override them in the 2016 classes 
   -  use `SCHEMA_VERSION` to choose the correct set of encoder/decoders and define a generic `{Element}{Encoder,Decoder} ` alias
- update all encoder/decoder unit tests to account for the various schema URLs variations
- add OMERO 5.3. to the list of Travis matrix builds

/cc @will-moore @chris-allan @jburel @knabar 
