### PR TITLE
Convert README from Markdown to reStructuredText

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include README.md
+include README.rst
 include requirements.txt
 include requirements-dev.txt

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/openmicroscopy/omero-marshal.png)](http://travis-ci.org/openmicroscopy/omero-marshal)
+.. image:: https://travis-ci.org/openmicroscopy/omero-marshal.png
+   :target: http://travis-ci.org/openmicroscopy/omero-marshal
 
 OMERO Marshal
 =============
@@ -16,11 +17,11 @@ Requirements
 Development Installation
 ========================
 
-1. Clone the repository
+1. Clone the repository::
 
         git clone git@github.com:openmicroscopy/omero-marshal.git
 
-2. Set up a virtualenv (http://www.pip-installer.org/) and activate it
+2. Set up a virtualenv (http://www.pip-installer.org/) and activate it::
 
         curl -O -k https://raw.github.com/pypa/virtualenv/master/virtualenv.py
         python virtualenv.py omero-marshal
@@ -31,7 +32,7 @@ Development Installation
 Running Tests
 =============
 
-Using py.test to run the unit tests:
+Using py.test to run the unit tests::
 
     	py.test tests/unit/
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     name='omero_marshal',
     version=VERSION,
     description='OMERO Marshal',
-    long_description=read('README.md'),
+    long_description=read('README.rst'),
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Pypi does not support rendering of Markdown readme files. Similarly to what has
been done for other pip distributed repositories (omego, yaclifw), this commit
converts the Readme from Markdown to reStructuredText which should be correctly
rendered by GitHub and Pypi.