### PR TITLE
Cap flake8 version to be sub-3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     zip_safe=True,
     include_package_data=True,
     platforms='any',
-    setup_requires=['flake8'],
+    setup_requires=['flake8<3.0.0'],
     install_requires=get_requirements(),
     tests_require=get_requirements('-dev'),
     entry_points="""


### PR DESCRIPTION
With the release of 3.0.0b2 to Pypi it looks like python setup.py flake8 hangs. This should restore the Travis builds.