### PR TITLE
Fix null strings

### DIFF
--- a/omero_marshal/decode/__init__.py
+++ b/omero_marshal/decode/__init__.py
@@ -41,7 +41,7 @@ class Decoder(object):
             prop,
             field_info.wrapper(
                 value
-            )
+            ) if value is not None else None
         )
 
     def decode(self, data):

--- a/tests/unit/test_base_decoder.py
+++ b/tests/unit/test_base_decoder.py
@@ -17,6 +17,13 @@ from omero_marshal import get_encoder, get_decoder, ROI_SCHEMA_URL
 
 class TestBaseDecoder(object):
 
+    AS_STRING = """{
+    "@type": "%s#ROI",
+    "@id": 1,
+    "Name": "the_name",
+    "Description": "the_description"
+}""" % ROI_SCHEMA_URL
+
     def assert_roi(self, roi, has_annotations=False):
         assert roi.__class__ == RoiI
         assert roi.id.val == 1L
@@ -40,16 +47,17 @@ class TestBaseDecoder(object):
         self.assert_externalInfo(v.details.externalInfo)
 
     def test_base_decoder_from_string(self):
-        data_as_string = """{
-    "@type": "%s#ROI",
-    "@id": 1,
-    "Name": "the_name",
-    "Description": "the_description"
-}""" % ROI_SCHEMA_URL
-        data = json.loads(data_as_string)
+        data = json.loads(self.AS_STRING)
         decoder = get_decoder(data['@type'])
         v = decoder.decode(data)
         self.assert_roi(v)
+
+    def test_null_string(self):
+        data = json.loads(self.AS_STRING)
+        data['Description'] = None
+        decoder = get_decoder(data['@type'])
+        v = decoder.decode(data)
+        assert v.description is None
 
 
 class TestPermissionsDecoder(object):


### PR DESCRIPTION
When we moved to utilizing the field information in 0.4.0 to correctly
wrap properties using the relevant OMERO rtype an early null check was
inadvertently removed.  This null check was in `omero.rtypes.rtype()`
and partially hidden.  As we are directly using `omero.rtypes.rstring`
now where relevant, and its semantics are to handle `None` as
`RStringI('')`, all `None`'s were being decoded as `RString('')`.

This PR fixes that by adding a null check into `set_property()`.  As
all `None`'s are effectively handled the same and this style mimics the
previous `omero.rtypes.rtype()` semantics the sole test case on the
singular property should suffice.  It is not necessary to test every
string property for round-trip nullability.

Candidate for immediate 0.4.1 release.

/cc @knabar 