### PR TITLE
Add support for Line/Polyline markers

### DIFF
--- a/omero_marshal/decode/decoders/line.py
+++ b/omero_marshal/decode/decoders/line.py
@@ -26,12 +26,22 @@ class Line201501Decoder(ShapeDecoder):
         self.set_property(v, 'y1', data.get('Y1'))
         self.set_property(v, 'x2', data.get('X2'))
         self.set_property(v, 'y2', data.get('Y2'))
+        self.set_markers(v, data)
         return v
+
+    def set_markers(self, v, data):
+        # Line markers have been introduced in Line objects in OMERO 5.3.0
+        pass
 
 
 class Line201606Decoder(Line201501Decoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Line'
+
+    def set_markers(self, v, data):
+        self.set_property(v, 'markerStart', data.get('MarkerStart'))
+        self.set_property(v, 'markerEnd', data.get('MarkerEnd'))
+        pass
 
 
 if SCHEMA_VERSION == '2015-01':

--- a/omero_marshal/decode/decoders/line.py
+++ b/omero_marshal/decode/decoders/line.py
@@ -26,22 +26,18 @@ class Line201501Decoder(ShapeDecoder):
         self.set_property(v, 'y1', data.get('Y1'))
         self.set_property(v, 'x2', data.get('X2'))
         self.set_property(v, 'y2', data.get('Y2'))
-        self.set_markers(v, data)
         return v
-
-    def set_markers(self, v, data):
-        # Line markers have been introduced in Line objects in OMERO 5.3.0
-        pass
 
 
 class Line201606Decoder(Line201501Decoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Line'
 
-    def set_markers(self, v, data):
+    def decode(self, data):
+        v = super(Line201606Decoder, self).decode(data)
         self.set_property(v, 'markerStart', data.get('MarkerStart'))
         self.set_property(v, 'markerEnd', data.get('MarkerEnd'))
-        pass
+        return v
 
 
 if SCHEMA_VERSION == '2015-01':

--- a/omero_marshal/decode/decoders/polyline.py
+++ b/omero_marshal/decode/decoders/polyline.py
@@ -23,12 +23,22 @@ class Polyline201501Decoder(ShapeDecoder):
     def decode(self, data):
         v = super(Polyline201501Decoder, self).decode(data)
         self.set_property(v, 'points', data.get('Points'))
+        self.set_markers(v, data)
         return v
+
+    def set_markers(self, v, data):
+        # Polyline markers have been introduced in Line objects in OMERO 5.3.0
+        pass
 
 
 class Polyline201606Decoder(Polyline201501Decoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Polyline'
+
+    def set_markers(self, v, data):
+        self.set_property(v, 'markerStart', data.get('MarkerStart'))
+        self.set_property(v, 'markerEnd', data.get('MarkerEnd'))
+        pass
 
 
 if SCHEMA_VERSION == '2015-01':

--- a/omero_marshal/decode/decoders/polyline.py
+++ b/omero_marshal/decode/decoders/polyline.py
@@ -23,22 +23,18 @@ class Polyline201501Decoder(ShapeDecoder):
     def decode(self, data):
         v = super(Polyline201501Decoder, self).decode(data)
         self.set_property(v, 'points', data.get('Points'))
-        self.set_markers(v, data)
         return v
-
-    def set_markers(self, v, data):
-        # Polyline markers have been introduced in Line objects in OMERO 5.3.0
-        pass
 
 
 class Polyline201606Decoder(Polyline201501Decoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Polyline'
 
-    def set_markers(self, v, data):
+    def decode(self, data):
+        v = super(Polyline201606Decoder, self).decode(data)
         self.set_property(v, 'markerStart', data.get('MarkerStart'))
         self.set_property(v, 'markerEnd', data.get('MarkerEnd'))
-        pass
+        return v
 
 
 if SCHEMA_VERSION == '2015-01':

--- a/omero_marshal/encode/encoders/line.py
+++ b/omero_marshal/encode/encoders/line.py
@@ -24,12 +24,21 @@ class Line201501Encoder(ShapeEncoder):
         self.set_if_not_none(v, 'Y1', obj.y1)
         self.set_if_not_none(v, 'X2', obj.x2)
         self.set_if_not_none(v, 'Y2', obj.y2)
+        self.set_markers(v, obj)
         return v
+
+    def set_markers(self, v, obj):
+        # Line markers have been introduced in Line objects in OMERO 5.3.0
+        pass
 
 
 class Line201606Encoder(Line201501Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Line'
+
+    def set_markers(self, v, obj):
+        self.set_if_not_none(v, 'MarkerStart', obj.markerStart)
+        self.set_if_not_none(v, 'MarkerEnd', obj.markerEnd)
 
 
 if SCHEMA_VERSION == '2015-01':

--- a/omero_marshal/encode/encoders/line.py
+++ b/omero_marshal/encode/encoders/line.py
@@ -24,21 +24,18 @@ class Line201501Encoder(ShapeEncoder):
         self.set_if_not_none(v, 'Y1', obj.y1)
         self.set_if_not_none(v, 'X2', obj.x2)
         self.set_if_not_none(v, 'Y2', obj.y2)
-        self.set_markers(v, obj)
         return v
-
-    def set_markers(self, v, obj):
-        # Line markers have been introduced in Line objects in OMERO 5.3.0
-        pass
 
 
 class Line201606Encoder(Line201501Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Line'
 
-    def set_markers(self, v, obj):
+    def encode(self, obj):
+        v = super(Line201606Encoder, self).encode(obj)
         self.set_if_not_none(v, 'MarkerStart', obj.markerStart)
         self.set_if_not_none(v, 'MarkerEnd', obj.markerEnd)
+        return v
 
 
 if SCHEMA_VERSION == '2015-01':

--- a/omero_marshal/encode/encoders/polyline.py
+++ b/omero_marshal/encode/encoders/polyline.py
@@ -21,21 +21,18 @@ class Polyline201501Encoder(ShapeEncoder):
     def encode(self, obj):
         v = super(Polyline201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'Points', obj.points)
-        self.set_markers(v, obj)
         return v
-
-    def set_markers(self, v, obj):
-        # Polyline markers have been introduced in Line objects in OMERO 5.3.0
-        pass
 
 
 class Polyline201606Encoder(Polyline201501Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Polyline'
 
-    def set_markers(self, v, obj):
+    def encode(self, obj):
+        v = super(Polyline201606Encoder, self).encode(obj)
         self.set_if_not_none(v, 'MarkerStart', obj.markerStart)
         self.set_if_not_none(v, 'MarkerEnd', obj.markerEnd)
+        return v
 
 
 if SCHEMA_VERSION == '2015-01':

--- a/omero_marshal/encode/encoders/polyline.py
+++ b/omero_marshal/encode/encoders/polyline.py
@@ -21,12 +21,21 @@ class Polyline201501Encoder(ShapeEncoder):
     def encode(self, obj):
         v = super(Polyline201501Encoder, self).encode(obj)
         self.set_if_not_none(v, 'Points', obj.points)
+        self.set_markers(v, obj)
         return v
+
+    def set_markers(self, v, obj):
+        # Polyline markers have been introduced in Line objects in OMERO 5.3.0
+        pass
 
 
 class Polyline201606Encoder(Polyline201501Encoder):
 
     TYPE = 'http://www.openmicroscopy.org/Schemas/OME/2016-06#Polyline'
+
+    def set_markers(self, v, obj):
+        self.set_if_not_none(v, 'MarkerStart', obj.markerStart)
+        self.set_if_not_none(v, 'MarkerEnd', obj.markerEnd)
 
 
 if SCHEMA_VERSION == '2015-01':

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -334,6 +334,9 @@ def polyline():
     o = PolylineI()
     populate_shape(o)
     o.points = rstring('0,0 1,2 3,5')
+    if SCHEMA_VERSION != '2015-01':
+        o.setMarkerStart('Arrow')
+        o.setMarkerEnd('Arrow')
     o.id = rlong(4L)
     return o
 
@@ -355,6 +358,9 @@ def line():
     o.setY1(0)
     o.setX2(1)
     o.setY2(2)
+    if SCHEMA_VERSION != '2015-01':
+        o.setMarkerStart('Arrow')
+        o.setMarkerEnd('Arrow')
     o.id = rlong(6L)
     return o
 

--- a/tests/unit/test_shape_decoders.py
+++ b/tests/unit/test_shape_decoders.py
@@ -250,6 +250,9 @@ class TestLineDecoder(TestShapeDecoder):
         assert v.x2.val == 1.0
         assert v.y2.__class__ is RDoubleI
         assert v.y2.val == 2.0
+        if SCHEMA_VERSION != '2015-01':
+            assert v.markerStart.val == 'Arrow'
+            assert v.markerEnd.val == 'Arrow'
 
 
 class TestPolylineDecoder(TestShapeDecoder):
@@ -262,6 +265,9 @@ class TestPolylineDecoder(TestShapeDecoder):
         self.assert_shape(v)
         assert v.id.val == 4L
         assert v.points.val == '0,0 1,2 3,5'
+        if SCHEMA_VERSION != '2015-01':
+            assert v.markerStart.val == 'Arrow'
+            assert v.markerEnd.val == 'Arrow'
 
 
 class TestPolygonDecoder(TestShapeDecoder):

--- a/tests/unit/test_shape_encoders.py
+++ b/tests/unit/test_shape_encoders.py
@@ -245,6 +245,9 @@ class TestPolylineEncoder(TestShapeEncoder):
         assert v['@id'] == 4L
         assert v['@type'] == '%s#Polyline' % ROI_SCHEMA_URL
         assert v['Points'] == '0,0 1,2 3,5'
+        if SCHEMA_VERSION != '2015-01':
+            assert v['MarkerStart'] == 'Arrow'
+            assert v['MarkerEnd'] == 'Arrow'
 
 
 class TestPolygonEncoder(TestShapeEncoder):
@@ -270,6 +273,9 @@ class TestLineEncoder(TestShapeEncoder):
         assert v['Y1'] == 0.0
         assert v['X2'] == 1.0
         assert v['Y2'] == 2.0
+        if SCHEMA_VERSION != '2015-01':
+            assert v['MarkerStart'] == 'Arrow'
+            assert v['MarkerEnd'] == 'Arrow'
 
 
 class TestRoiEncoder(TestShapeEncoder):


### PR DESCRIPTION
Marker attributes were added to `Line` and `Polyline` OMERO objects while aligning to the schema in 5.3 - see https://github.com/openmicroscopy/openmicroscopy/pull/4533.

This PR adds support for these markers in the shape encoders/decoders together with the corresponding unit tests.

/cc @will-moore @chris-allan 