### PR TITLE
Handle unloaded details

### DIFF
--- a/omero_marshal/encode/__init__.py
+++ b/omero_marshal/encode/__init__.py
@@ -45,7 +45,7 @@ class Encoder(object):
             obj_id = unwrap(obj.id)
             if obj_id is not None:
                 v['@id'] = obj_id
-        if hasattr(obj, 'details'):
+        if hasattr(obj, 'details') and obj.details is not None:
             encoder = self.ctx.get_encoder(obj.details.__class__)
             v['omero:details'] = encoder.encode(obj.details)
 

--- a/tests/unit/test_base_encoder.py
+++ b/tests/unit/test_base_encoder.py
@@ -63,6 +63,17 @@ class TestBaseEncoder(object):
             }
         }
 
+    def test_base_encoder_unloaded_details(self, roi):
+        roi.unloadDetails()
+        encoder = get_encoder(roi.__class__)
+        v = encoder.encode(roi)
+        assert v == {
+            '@id': 1L,
+            '@type': '%s#ROI' % ROI_SCHEMA_URL,
+            'Name': 'the_name',
+            'Description': 'the_description'
+        }
+
     def test_base_encoder_with_unloaded_details_children(
             self, roi_with_unloaded_details_children):
         encoder = get_encoder(roi_with_unloaded_details_children.__class__)


### PR DESCRIPTION
If details are unloaded, the object cannot currently be encoded. This PR fixes that.