### PR TITLE
Add convenience fields to encoded Permissions

### DIFF
--- a/omero_marshal/encode/encoders/permissions.py
+++ b/omero_marshal/encode/encoders/permissions.py
@@ -24,6 +24,13 @@ class PermissionsEncoder(Encoder):
         v['canDelete'] = obj.canDelete()
         v['canEdit'] = obj.canEdit()
         v['canLink'] = obj.canLink()
+        v['isWorldWrite'] = obj.isWorldWrite()
+        v['isWorldRead'] = obj.isWorldRead()
+        v['isGroupWrite'] = obj.isGroupWrite()
+        v['isGroupRead'] = obj.isGroupRead()
+        v['isGroupAnnotate'] = obj.isGroupAnnotate()
+        v['isUserWrite'] = obj.isUserWrite()
+        v['isUserRead'] = obj.isUserRead()
         return v
 
 encoder = (PermissionsI, PermissionsEncoder)

--- a/tests/unit/test_base_encoder.py
+++ b/tests/unit/test_base_encoder.py
@@ -48,7 +48,14 @@ class TestBaseEncoder(object):
                     'canDelete': True,
                     'canEdit': True,
                     'canLink': True,
-                    'perm': 'rwrwrw'
+                    'perm': 'rwrwrw',
+                    'isGroupAnnotate': True,
+                    'isGroupRead': True,
+                    'isGroupWrite': True,
+                    'isUserRead': True,
+                    'isUserWrite': True,
+                    'isWorldRead': True,
+                    'isWorldWrite': True
                 },
                 'externalInfo': {
                     '@type': 'TBD#ExternalInfo',
@@ -88,7 +95,14 @@ class TestBaseEncoder(object):
                     'canDelete': True,
                     'canEdit': True,
                     'canLink': True,
-                    'perm': 'rwrwrw'
+                    'perm': 'rwrwrw',
+                    'isGroupAnnotate': True,
+                    'isGroupRead': True,
+                    'isGroupWrite': True,
+                    'isUserRead': True,
+                    'isUserWrite': True,
+                    'isWorldRead': True,
+                    'isWorldWrite': True
                 },
                 'externalInfo': {
                     '@type': 'TBD#ExternalInfo',
@@ -145,7 +159,14 @@ class TestDetailsEncoder(object):
             'canAnnotate': True,
             'canDelete': True,
             'canEdit': True,
-            'canLink': True
+            'canLink': True,
+            'isGroupAnnotate': True,
+            'isGroupRead': True,
+            'isGroupWrite': True,
+            'isUserRead': True,
+            'isUserWrite': True,
+            'isWorldRead': True,
+            'isWorldWrite': True
         }
 
     def test_permissions_encoder(self, permissions):

--- a/tests/unit/test_shape_encoders.py
+++ b/tests/unit/test_shape_encoders.py
@@ -110,7 +110,14 @@ class TestShapeEncoder(object):
                 'canDelete': True,
                 'canEdit': True,
                 'canLink': True,
-                'perm': 'rwrwrw'
+                'perm': 'rwrwrw',
+                'isGroupAnnotate': True,
+                'isGroupRead': True,
+                'isGroupWrite': True,
+                'isUserRead': True,
+                'isUserWrite': True,
+                'isWorldRead': True,
+                'isWorldWrite': True
             },
             'externalInfo': {
                 '@type': 'TBD#ExternalInfo',


### PR DESCRIPTION
Incredibly useful if you want to know the permission state of a given group and don't want to be parsing the `perm` string to find out.