### PR TITLE
OMERO version check: bug fix

### DIFF
--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -54,7 +54,7 @@ def get_schema_version(version):
     v = StrictVersion(m.group(1))
     if v >= StrictVersion('5.1.0') and v < StrictVersion('5.3.0'):
         return '2015-01'
-    elif v >= StrictVersion('5.3.0'):
+    elif v >= StrictVersion('5.3.0') and v < StrictVersion('5.5.0'):
         return '2016-06'
     else:
         raise Exception("Unsupported OMERO version: " + version)

--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -54,7 +54,7 @@ def get_schema_version(version):
     v = StrictVersion(m.group(1))
     if v >= StrictVersion('5.1.0') and v < StrictVersion('5.3.0'):
         return '2015-01'
-    elif v == StrictVersion('5.3.0'):
+    elif v >= StrictVersion('5.3.0'):
         return '2016-06'
     else:
         raise Exception("Unsupported OMERO version: " + version)

--- a/tests/unit/test_schema_version.py
+++ b/tests/unit/test_schema_version.py
@@ -25,7 +25,10 @@ class SchemaFixture(object):
 SFS = (SchemaFixture("5.1.0-ice35-b40", "2015-01"),
        SchemaFixture("5.2.0-ice35-b12", "2015-01"),
        SchemaFixture("5.2.4-ice35-b23", "2015-01"),
-       SchemaFixture("5.3.0-m2-ice35-b20", "2016-06"))
+       SchemaFixture("5.3.0-m2-ice35-b20", "2016-06"),
+       SchemaFixture("5.3.0-ice36-b59", "2016-06"),
+       SchemaFixture("5.3.1-ice36-SNAPSHOT", "2016-06"),
+       SchemaFixture("5.4.0-ice36-SNAPSHOT", "2016-06"))
 
 
 @pytest.mark.parametrize("f", SFS, ids=[x.omero_version for x in SFS])


### PR DESCRIPTION
As part of the multi-schema support in https://github.com/openmicroscopy/omero-marshal/pull/12, a top-level `get_schema_version()` method was added allowing to map the OMERO version to the Data Model version.

As reported by @mtbc, following the release of OMERO 5.3.0, the very strict version check for the latest schema in https://github.com/openmicroscopy/omero-marshal/blob/v0.5.0/omero_marshal/__init__.py#L57 breaks the usage of `omero-marshal` for any OMERO 5.3.x where x > 0.

This PR proposes to fix this bug by using a greater than check rather than a strict equality check so that any version greater than OMERO 5.3.0 and lower than OMERO 5.5.0 e.g. OMERO 5.3.1 or OMERO 5.4.0 for instance will be mapped to the 2016-06 data model schema.

A benefit of this conversative approach is we do not create an ambiguous situation where 2 different versions of `omero-marshal` could return two different schema versions for a future OMERO version e.g. 7.0.0. On the other hand, each new major/minor OMERO series needs to be "registered" and a new version of `omero-marshal`  needs to be released and consumed in order to be functional.

A more flexible alternative would be to make the check open-ended so that a schema is always defined independently of the OMERO version. /cc @chris-allan @jburel @joshmoore 
