### PR TITLE
Unpin the OMERO 5.3.0-m7 version and test with the latest OMERO 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   matrix:
     - OMERO_VERSION=5.1
     - OMERO_VERSION=5.2
-    - OMERO_VERSION=5.3.0-m7
+    - OMERO_VERSION=5.3
 
 before_install:
   - wget http://downloads.openmicroscopy.org/ice/experimental/${ICE}.tar.xz -O /tmp/${ICE}.tar.xz


### PR DESCRIPTION
Following the release of omego 0.6.0, `omego download --ice 3.5` should be functional again for all OMERO 5.3.x artifacts.

Reverts the capping introduced in https://github.com/openmicroscopy/omero-marshal/commit/989ad906b6a2495a433f646e78cf74fb662b8de6

To test this PR, check Travis is green and that the 5.3 component is used the latest OMERO 5.3 release.

/cc @jburel @will-moore 