### PR TITLE
Drop the specific milestone for OMERO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - OMERO_VERSION=5.1
     - OMERO_VERSION=5.2
     - OMERO_VERSION=5.3
-    - OMERO_VERSION=5.4.0-m2
+    - OMERO_VERSION=5.4
 
 before_install:
   # The installation of the python dependencies must be done in that level for now


### PR DESCRIPTION
Following https://www.openmicroscopy.org/2017/10/09/omero-5-4-0.html

To test this PR, check Travis is green. Review the matrix execution for OMERO 5.4 and verify that the OMERO 5.4.0 Python package is downloaded and used for running the unit tests.