### PR TITLE
5.5 and schema version check

### DIFF
--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -45,7 +45,7 @@ def get_decoder(t):
         return None
 
 
-VERSION_REGEXP = re.compile('^(\d+\.\d+\.\d+)')
+VERSION_REGEXP = re.compile(r'^(\d+\.\d+\.\d+)')
 
 
 def get_schema_version(version):

--- a/omero_marshal/__init__.py
+++ b/omero_marshal/__init__.py
@@ -55,7 +55,7 @@ def get_schema_version(version):
     v = StrictVersion(m.group(1))
     if v >= StrictVersion('5.1.0') and v < StrictVersion('5.3.0'):
         return '2015-01'
-    elif v >= StrictVersion('5.3.0') and v < StrictVersion('5.5.0'):
+    elif v >= StrictVersion('5.3.0') and v < StrictVersion('6.0.0'):
         return '2016-06'
     else:
         raise Exception("Unsupported OMERO version: " + version)

--- a/tests/unit/test_schema_version.py
+++ b/tests/unit/test_schema_version.py
@@ -29,7 +29,8 @@ SFS = (SchemaFixture("5.1.0-ice35-b40", "2015-01"),
        SchemaFixture("5.3.0-m2-ice35-b20", "2016-06"),
        SchemaFixture("5.3.0-ice36-b59", "2016-06"),
        SchemaFixture("5.3.1-ice36-SNAPSHOT", "2016-06"),
-       SchemaFixture("5.4.0-ice36-SNAPSHOT", "2016-06"))
+       SchemaFixture("5.4.0-ice36-SNAPSHOT", "2016-06"),
+       SchemaFixture("5.5.0-ice36-SNAPSHOT", "2016-06"))
 
 
 @pytest.mark.parametrize("f", SFS, ids=[x.omero_version for x in SFS])


### PR DESCRIPTION
See https://github.com/openmicroscopy/openmicroscopy/pull/5913#issuecomment-440948870

This PR relaxes the checking of OMERO versions associated with the 2016-06 schema. It makes an assumption that any OMERO 5.3.0+ versions will be using the 2016-06 OME schema. On the other hand this should reduce the cost of releasing a patch version of `omero-marshal` every time we want to start an OMERO 5.x series.

/cc @joshmoore @jburel 

Proposed tag :`0.5.4`