### PR TITLE
Encode Python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
+---
 language: python
 dist: xenial
 # This (sudo: false) is needed to "run on container-based infrastructure" on
 # which cache: is available
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: required
+python: 2.7
 
 env:
   matrix:


### PR DESCRIPTION
Travis is now switching to 3.6 as the default. Until Python 3 becomes supported this should ensure builds keep passing.